### PR TITLE
feat(nix): autonity NixOS module ⛵

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "autonity": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -39,24 +41,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1776548001,
@@ -76,26 +60,11 @@
     "root": {
       "inputs": {
         "autonity": "autonity",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -1,8 +1,47 @@
 {
   "nodes": {
+    "autonity": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776506148,
+        "narHash": "sha256-OTEDw5t4DWg69/o8Gf/Kr4NMJpgB4ZZ5mGQLLueNWE8=",
+        "owner": "klazomenai",
+        "repo": "autonity",
+        "rev": "c857b7408b0057bd6e19bd018d2c1c7889714827",
+        "type": "github"
+      },
+      "original": {
+        "owner": "klazomenai",
+        "repo": "autonity",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -36,11 +75,27 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "autonity": "autonity",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
     # with `autonity.packages.<system>.autonity-portable`.
     autonity.url = "github:klazomenai/autonity";
     autonity.inputs.nixpkgs.follows = "nixpkgs";
+    autonity.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -33,15 +33,18 @@
       # Top-level aggregate module. Service modules are imported from
       # `modules/default.nix`. Flake inputs that provide runtime packages
       # (autonity for now; blockscout / blockscout-frontend as they
-      # integrate) are exposed to every imported service module via
-      # `_module.args` so the modules stay pure — they never reach into
-      # the flake-outputs closure directly.
-      nixosModules.default =
-        { pkgs, ... }:
-        {
-          imports = [ ./modules ];
-          _module.args.autonityPkgs = autonity.packages.${pkgs.stdenv.hostPlatform.system};
-        };
+      # integrate) are exposed via a `nixpkgs.overlays` entry so service
+      # modules can use the standard `mkPackageOption pkgs "<name>" { }`
+      # idiom — uniform with `CONTRIBUTING.md` and the rest of nixpkgs.
+      nixosModules.default = {
+        imports = [ ./modules ];
+        nixpkgs.overlays = [
+          (final: _prev: {
+            autonity = autonity.packages.${final.stdenv.hostPlatform.system}.default;
+            autonity-portable = autonity.packages.${final.stdenv.hostPlatform.system}.autonity-portable;
+          })
+        ];
+      };
       nixosModules.autonity-blockscout = self.nixosModules.default;
     }
     // flake-utils.lib.eachSystem systems (

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,14 @@
     flake-utils.url = "github:numtide/flake-utils";
     # flake-utils no longer carries a nixpkgs input, so no `follows` wiring
     # is needed here.
+
+    # Autonity node package — produced by the `klazomenai/autonity` fork's
+    # flake. The NixOS autonity module defaults `services.autonity.package`
+    # to this input's `packages.<system>.default` (minimal ELF variant).
+    # Operators wanting the portable bash-wrapped variant can override
+    # with `autonity.packages.<system>.autonity-portable`.
+    autonity.url = "github:klazomenai/autonity";
+    autonity.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -13,6 +21,7 @@
       self,
       nixpkgs,
       flake-utils,
+      autonity,
     }:
     let
       # Scope locked to x86_64-linux for the glue repo and all service
@@ -22,10 +31,18 @@
     in
     {
       # Top-level aggregate module. Service modules are imported from
-      # `modules/default.nix` — initially empty; filled as each service
-      # module lands via its own PR.
-      nixosModules.default = ./modules;
-      nixosModules.autonity-blockscout = ./modules;
+      # `modules/default.nix`. Flake inputs that provide runtime packages
+      # (autonity for now; blockscout / blockscout-frontend as they
+      # integrate) are exposed to every imported service module via
+      # `_module.args` so the modules stay pure — they never reach into
+      # the flake-outputs closure directly.
+      nixosModules.default =
+        { pkgs, ... }:
+        {
+          imports = [ ./modules ];
+          _module.args.autonityPkgs = autonity.packages.${pkgs.stdenv.hostPlatform.system};
+        };
+      nixosModules.autonity-blockscout = self.nixosModules.default;
     }
     // flake-utils.lib.eachSystem systems (
       system:

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -1,0 +1,312 @@
+# NixOS service module for Autonity — a hardened systemd unit that runs
+# the Autonity blockchain node (Go, geth-derived). Defense-in-depth
+# hardening follows the matrix documented in the `nix-modules-hardening`
+# Claude skill; see `../CONTRIBUTING.md` for the per-repo summary.
+#
+# Expects `autonityPkgs` to be passed via `_module.args` from the flake
+# output (see `../flake.nix`). `autonityPkgs.default` is the minimal ELF
+# variant; operators wanting the bash-wrapped `autonity-portable` can
+# set `services.autonity.package` explicitly.
+{
+  config,
+  lib,
+  pkgs,
+  autonityPkgs,
+  ...
+}:
+
+let
+  cfg = config.services.autonity;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    types
+    literalExpression
+    concatStringsSep
+    ;
+
+  # CLI flag attrset → shell string via lib.cli. Null values are dropped,
+  # so flags only appear when an option is active.
+  argAttrs = {
+    datadir = cfg.dataDir;
+    syncmode = cfg.syncMode;
+    gcmode = cfg.gcMode;
+    cache = cfg.cache;
+    ipcdisable = true;
+    port = cfg.p2p.port;
+    maxpeers = cfg.p2p.maxPeers;
+    nat = if cfg.p2p.natExtIp != null then "extip:${cfg.p2p.natExtIp}" else null;
+    # MainNet is the upstream default (no flag); only Bakerloo testnet
+    # needs an explicit switch.
+    bakerloo = cfg.network == "bakerloo";
+
+    http = cfg.http.enable;
+    "http.addr" = if cfg.http.enable then cfg.http.addr else null;
+    "http.port" = if cfg.http.enable then cfg.http.port else null;
+    "http.api" =
+      if cfg.http.enable && cfg.http.apis != null then concatStringsSep "," cfg.http.apis else null;
+    "http.vhosts" =
+      if cfg.http.enable && cfg.http.vhosts != null then concatStringsSep "," cfg.http.vhosts else null;
+
+    ws = cfg.ws.enable;
+    "ws.addr" = if cfg.ws.enable then cfg.ws.addr else null;
+    "ws.port" = if cfg.ws.enable then cfg.ws.port else null;
+    "ws.api" = if cfg.ws.enable && cfg.ws.apis != null then concatStringsSep "," cfg.ws.apis else null;
+
+    bootnodes = if cfg.bootnodes != null then concatStringsSep "," cfg.bootnodes else null;
+
+    metrics = cfg.metrics.enable;
+  };
+
+  args = lib.cli.toGNUCommandLineShell { } argAttrs;
+
+in
+{
+  options.services.autonity = {
+    enable = mkEnableOption "Autonity blockchain node";
+
+    package = mkOption {
+      type = types.package;
+      default = autonityPkgs.default;
+      defaultText = literalExpression "autonityPkgs.default";
+      description = ''
+        The Autonity package to run. Defaults to the `klazomenai/autonity`
+        flake input's `packages.<system>.default` (minimal ELF variant).
+      '';
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/var/lib/autonity";
+      description = ''
+        Chain-data directory, surfaced via systemd `StateDirectory`. The
+        path is managed by systemd and does not need to exist on the host
+        ahead of service start.
+      '';
+    };
+
+    network = mkOption {
+      type = types.enum [
+        "mainnet"
+        "bakerloo"
+      ];
+      default = "mainnet";
+      description = ''
+        Autonity network to join. MainNet is the upstream default (no
+        flag); selecting Bakerloo (testnet) passes `--bakerloo` to the
+        binary.
+      '';
+    };
+
+    syncMode = mkOption {
+      type = types.enum [
+        "full"
+        "snap"
+      ];
+      default = "full";
+      description = ''
+        Chain sync mode. Blockscout's trace indexing requires
+        `debug_traceTransaction`, so keep `full` (paired with
+        `gcMode = "archive"`) when this node backs Blockscout.
+      '';
+    };
+
+    gcMode = mkOption {
+      type = types.enum [
+        "archive"
+        "full"
+      ];
+      default = "archive";
+      description = ''
+        Storage pruning mode. Blockscout historical-state queries
+        require `archive`.
+      '';
+    };
+
+    cache = mkOption {
+      type = types.ints.positive;
+      default = 4096;
+      description = "In-memory cache size (MiB) for state and block data.";
+    };
+
+    http = {
+      enable = mkEnableOption "the JSON-RPC HTTP server" // {
+        default = true;
+      };
+      addr = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = ''
+          Listen address for the HTTP JSON-RPC server. Defaults to
+          loopback — do not broadcast externally without a TLS reverse
+          proxy and authentication in front of it.
+        '';
+      };
+      port = mkOption {
+        type = types.port;
+        default = 8545;
+      };
+      apis = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        example = [
+          "eth"
+          "net"
+          "web3"
+          "debug"
+        ];
+        description = ''
+          List of APIs to expose on HTTP (joined with `,` and passed as
+          `--http.api`). `null` lets Autonity use its default set.
+        '';
+      };
+      vhosts = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+        description = ''
+          List of virtual hostnames the HTTP server will accept. Setting
+          this REPLACES the default set (including `localhost`) —
+          include `localhost` explicitly if in-container health checks
+          target it, otherwise the probes will be rejected.
+        '';
+      };
+    };
+
+    ws = {
+      enable = mkEnableOption "the JSON-RPC WebSocket server" // {
+        default = true;
+      };
+      addr = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 8546;
+      };
+      apis = mkOption {
+        type = types.nullOr (types.listOf types.str);
+        default = null;
+      };
+    };
+
+    p2p = {
+      port = mkOption {
+        type = types.port;
+        default = 30303;
+        description = ''
+          P2P discovery (UDP) and RLPx (TCP) port. Autonity binds this
+          externally on all interfaces by design; it is the only
+          non-loopback port this module opens.
+        '';
+      };
+      maxPeers = mkOption {
+        type = types.ints.unsigned;
+        default = 50;
+      };
+      natExtIp = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          When set, passed as `--nat extip:<value>` so Autonity
+          advertises this external IP in its enode. Without this,
+          Autonity advertises the interface IP as seen inside its
+          network namespace (often `127.0.0.1` behind NAT), and peers
+          cannot reach the node.
+        '';
+      };
+    };
+
+    bootnodes = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      description = ''
+        Override the baked-in bootnode list (joined with `,` and passed
+        as `--bootnodes`). `null` uses Autonity's defaults.
+      '';
+    };
+
+    metrics.enable = mkEnableOption "the Autonity Prometheus metrics endpoint";
+
+    extraArgs = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      description = ''
+        Additional CLI arguments passed verbatim to the `autonity`
+        binary. Escape hatch for flags this module does not yet expose
+        as options.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.autonity = {
+      description = "Autonity blockchain node";
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/autonity ${args} ${lib.escapeShellArgs cfg.extraArgs}";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        DynamicUser = true;
+        StateDirectory = "autonity";
+        StateDirectoryMode = "0700";
+
+        # Defense-in-depth hardening. See `nix-modules-hardening` skill
+        # for the full matrix and the per-option rationale.
+        CapabilityBoundingSet = [ "" ];
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true; # Go has no runtime JIT.
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        # AF_NETLINK is required: Autonity (go-ethereum derived) uses
+        # netlink sockets to enumerate network interfaces for NAT and
+        # discovery address selection. Removing this family makes the
+        # P2P subsystem fail at startup with
+        # "operation not supported by protocol".
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@cpu-emulation @debug @keyring @memlock @mount @obsolete @privileged @resources @setuid"
+        ];
+        UMask = "0077";
+      };
+    };
+
+    # Surface a warning if an operator broadens the JSON-RPC or WS bind
+    # beyond loopback — the default is 127.0.0.1 for both, and exposure
+    # should be a conscious decision (typically mediated via nginx).
+    warnings =
+      lib.optional (cfg.http.enable && cfg.http.addr != "127.0.0.1" && cfg.http.addr != "localhost")
+        "services.autonity.http.addr is `${cfg.http.addr}` — the HTTP JSON-RPC server will be reachable beyond loopback. Ensure a TLS reverse proxy and authentication front it."
+      ++
+        lib.optional (cfg.ws.enable && cfg.ws.addr != "127.0.0.1" && cfg.ws.addr != "localhost")
+          "services.autonity.ws.addr is `${cfg.ws.addr}` — the WebSocket server will be reachable beyond loopback. Ensure a TLS reverse proxy and authentication front it.";
+  };
+}

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -218,8 +218,9 @@ in
           When set, passed as `--nat extip:<value>` so Autonity
           advertises this external IP in its enode. Without this,
           Autonity advertises the interface IP as seen inside its
-          network namespace (often `127.0.0.1` behind NAT), and peers
-          cannot reach the node.
+          network namespace (often a private/NATed or container
+          interface address — RFC1918 in the typical case), and
+          peers cannot reach the node.
         '';
       };
       openFirewall = mkOption {

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -3,15 +3,15 @@
 # hardening follows the matrix documented in the `nix-modules-hardening`
 # Claude skill; see `../CONTRIBUTING.md` for the per-repo summary.
 #
-# Expects `autonityPkgs` to be passed via `_module.args` from the flake
-# output (see `../flake.nix`). `autonityPkgs.default` is the minimal ELF
-# variant; operators wanting the bash-wrapped `autonity-portable` can
-# set `services.autonity.package` explicitly.
+# The `klazomenai/autonity` flake is wired into `pkgs` via a
+# `nixpkgs.overlays` entry on the glue-repo's `nixosModules.default`
+# (see `../flake.nix`), so `pkgs.autonity` resolves to the minimal ELF
+# variant and `pkgs.autonity-portable` to the bash-wrapped one.
+# Operators can override `services.autonity.package` to pick either.
 {
   config,
   lib,
   pkgs,
-  autonityPkgs,
   ...
 }:
 
@@ -20,9 +20,9 @@ let
   inherit (lib)
     mkEnableOption
     mkOption
+    mkPackageOption
     mkIf
     types
-    literalExpression
     concatStringsSep
     ;
 
@@ -66,23 +66,21 @@ in
   options.services.autonity = {
     enable = mkEnableOption "Autonity blockchain node";
 
-    package = mkOption {
-      type = types.package;
-      default = autonityPkgs.default;
-      defaultText = literalExpression "autonityPkgs.default";
-      description = ''
-        The Autonity package to run. Defaults to the `klazomenai/autonity`
-        flake input's `packages.<system>.default` (minimal ELF variant).
-      '';
-    };
+    package = mkPackageOption pkgs "autonity" { };
 
     dataDir = mkOption {
       type = types.str;
       default = "/var/lib/autonity";
       description = ''
-        Chain-data directory, surfaced via systemd `StateDirectory`. The
-        path is managed by systemd and does not need to exist on the host
-        ahead of service start.
+        Chain-data directory. Must be an absolute path under `/var/lib/`
+        (enforced via `config.assertions`). The relative part of the
+        path is used as the systemd `StateDirectory`, so the directory
+        is created, owned, and permission-hardened by systemd on each
+        service start — no manual `mkdir` or `chown` needed on the host.
+        Paths outside `/var/lib/` are not supported by this module:
+        `ProtectSystem = "strict"` would block writes there, so an
+        operator needing a custom location must provide their own
+        systemd override rather than just changing this option.
       '';
     };
 
@@ -198,7 +196,7 @@ in
         description = ''
           P2P discovery (UDP) and RLPx (TCP) port. Autonity binds this
           externally on all interfaces by design; it is the only
-          non-loopback port this module opens.
+          non-loopback port this module configures Autonity to bind.
         '';
       };
       maxPeers = mkOption {
@@ -214,6 +212,15 @@ in
           Autonity advertises the interface IP as seen inside its
           network namespace (often `127.0.0.1` behind NAT), and peers
           cannot reach the node.
+        '';
+      };
+      openFirewall = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Open the P2P port in the host firewall. Peer discovery needs
+          both UDP (discovery) and TCP (RLPx) on the same port number,
+          so both families are opened when this is true.
         '';
       };
     };
@@ -241,6 +248,25 @@ in
   };
 
   config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.hasPrefix "/var/lib/" cfg.dataDir && cfg.dataDir != "/var/lib/";
+        message = ''
+          services.autonity.dataDir (`${cfg.dataDir}`) must be an
+          absolute path under `/var/lib/`. Paths outside `/var/lib/`
+          are not supported by this module — `ProtectSystem = "strict"`
+          blocks writes elsewhere and systemd `StateDirectory` is
+          scoped to `/var/lib/`. If you need a custom location,
+          provide a systemd override rather than changing this option.
+        '';
+      }
+    ];
+
+    networking.firewall = mkIf cfg.p2p.openFirewall {
+      allowedTCPPorts = [ cfg.p2p.port ];
+      allowedUDPPorts = [ cfg.p2p.port ];
+    };
+
     systemd.services.autonity = {
       description = "Autonity blockchain node";
       after = [ "network-online.target" ];
@@ -253,7 +279,11 @@ in
         RestartSec = "5s";
 
         DynamicUser = true;
-        StateDirectory = "autonity";
+        # Derived from cfg.dataDir so overriding dataDir also moves the
+        # systemd-managed state directory. The `config.assertions` above
+        # enforces that cfg.dataDir lives under /var/lib/, so this
+        # removePrefix is always defined.
+        StateDirectory = lib.removePrefix "/var/lib/" cfg.dataDir;
         StateDirectoryMode = "0700";
 
         # Defense-in-depth hardening. See `nix-modules-hardening` skill
@@ -301,12 +331,22 @@ in
 
     # Surface a warning if an operator broadens the JSON-RPC or WS bind
     # beyond loopback — the default is 127.0.0.1 for both, and exposure
-    # should be a conscious decision (typically mediated via nginx).
+    # should be a conscious decision (typically mediated via nginx). The
+    # loopback-safe set includes both IPv4 (`127.0.0.1`) and IPv6 (`::1`)
+    # loopback addresses plus the `localhost` hostname so IPv6-only dev
+    # setups do not trip a false-positive warning.
     warnings =
-      lib.optional (cfg.http.enable && cfg.http.addr != "127.0.0.1" && cfg.http.addr != "localhost")
-        "services.autonity.http.addr is `${cfg.http.addr}` — the HTTP JSON-RPC server will be reachable beyond loopback. Ensure a TLS reverse proxy and authentication front it."
+      let
+        loopbackSafe = [
+          "127.0.0.1"
+          "::1"
+          "localhost"
+        ];
+      in
+      lib.optional (cfg.http.enable && !builtins.elem cfg.http.addr loopbackSafe)
+        "services.autonity.http.addr is `${cfg.http.addr}` — the HTTP JSON-RPC server will be reachable beyond loopback. Ensure a TLS reverse proxy and authentication in front of it."
       ++
-        lib.optional (cfg.ws.enable && cfg.ws.addr != "127.0.0.1" && cfg.ws.addr != "localhost")
-          "services.autonity.ws.addr is `${cfg.ws.addr}` — the WebSocket server will be reachable beyond loopback. Ensure a TLS reverse proxy and authentication front it.";
+        lib.optional (cfg.ws.enable && !builtins.elem cfg.ws.addr loopbackSafe)
+          "services.autonity.ws.addr is `${cfg.ws.addr}` — the WebSocket server will be reachable beyond loopback. Ensure a TLS reverse proxy and authentication in front of it.";
   };
 }

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -69,17 +69,25 @@ in
     package = mkPackageOption pkgs "autonity" { };
 
     dataDir = mkOption {
-      type = types.str;
+      # Regex enforces `/var/lib/<segment>(/<segment>)*` where each
+      # segment starts with a non-`.` non-`/` char. This rejects
+      # traversal (`/var/lib/../tmp`), current-dir (`/var/lib/./foo`),
+      # hidden names (`/var/lib/.hidden`), trailing slashes, and empty
+      # segments (`/var/lib//foo`) at option-set time, so the
+      # `removePrefix` below and the documented "under /var/lib/"
+      # guarantee are both actually safe.
+      type = types.strMatching "^/var/lib/[^./][^/]*(/[^./][^/]*)*$";
       default = "/var/lib/autonity";
       description = ''
-        Chain-data directory. Must be an absolute path under `/var/lib/`
-        (enforced via `config.assertions`). The relative part of the
-        path is used as the systemd `StateDirectory`, so the directory
-        is created, owned, and permission-hardened by systemd on each
-        service start — no manual `mkdir` or `chown` needed on the host.
-        Paths outside `/var/lib/` are not supported by this module:
-        `ProtectSystem = "strict"` would block writes there, so an
-        operator needing a custom location must provide their own
+        Chain-data directory. Must be an absolute path under `/var/lib/`,
+        with segments that do not start with `.` and contain no `..`
+        traversal (enforced via the option type). The relative part of
+        the path is used as the systemd `StateDirectory`, so the
+        directory is created, owned, and permission-hardened by systemd
+        on each service start — no manual `mkdir` or `chown` needed on
+        the host. Paths outside `/var/lib/` are not supported by this
+        module: `ProtectSystem = "strict"` would block writes there, so
+        an operator needing a custom location must provide their own
         systemd override rather than just changing this option.
       '';
     };
@@ -248,19 +256,9 @@ in
   };
 
   config = mkIf cfg.enable {
-    assertions = [
-      {
-        assertion = lib.hasPrefix "/var/lib/" cfg.dataDir && cfg.dataDir != "/var/lib/";
-        message = ''
-          services.autonity.dataDir (`${cfg.dataDir}`) must be an
-          absolute path under `/var/lib/`. Paths outside `/var/lib/`
-          are not supported by this module — `ProtectSystem = "strict"`
-          blocks writes elsewhere and systemd `StateDirectory` is
-          scoped to `/var/lib/`. If you need a custom location,
-          provide a systemd override rather than changing this option.
-        '';
-      }
-    ];
+    # `dataDir` is validated at the option-type layer (`types.strMatching`)
+    # — no runtime assertion needed. The type-level check fails earlier
+    # and with a clearer error than `config.assertions`.
 
     networking.firewall = mkIf cfg.p2p.openFirewall {
       allowedTCPPorts = [ cfg.p2p.port ];

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -278,9 +278,9 @@ in
 
         DynamicUser = true;
         # Derived from cfg.dataDir so overriding dataDir also moves the
-        # systemd-managed state directory. The `config.assertions` above
-        # enforces that cfg.dataDir lives under /var/lib/, so this
-        # removePrefix is always defined.
+        # systemd-managed state directory. The `dataDir` option's
+        # `types.strMatching` constraint enforces that cfg.dataDir lives
+        # under /var/lib/, so this removePrefix is always defined.
         StateDirectory = lib.removePrefix "/var/lib/" cfg.dataDir;
         StateDirectoryMode = "0700";
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -9,8 +9,8 @@
 
 {
   imports = [
+    ./autonity.nix
     # Service modules land here as they ship:
-    #   ./autonity.nix
     #   ./blockscout-postgresql.nix
     #   ./blockscout-redis.nix
     #   ./blockscout-backend.nix

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,10 +1,14 @@
 # Aggregate NixOS module for the autonity-blockscout-nixos stack.
 #
-# Service modules are added to this imports list as they land in
-# subsequent PRs. The bootstrap aggregate is intentionally empty so the
-# glue-repo scaffolding (flake.nix, devenv.nix, CI, release-please,
-# issue/PR templates, LICENSE, CONTRIBUTING.md) can be reviewed and
-# merged independently of any service-module semantics.
+# Composes every service module shipped by this repo via the imports
+# list below. New service modules are added here as they land; the
+# commented placeholders show the remaining planned additions for the
+# Blockscout side of the stack. The bootstrap PR (#2) intentionally
+# shipped this file empty so the glue-repo scaffolding (flake.nix,
+# devenv.nix, CI, release-please, issue/PR templates, LICENSE,
+# CONTRIBUTING.md) could be reviewed independently of any service-
+# module semantics; this PR introduces the first real service module
+# (`autonity.nix`).
 { ... }:
 
 {


### PR DESCRIPTION
## Summary

First service module for the glue repo. `services.autonity` runs Autonity as a hardened systemd unit — Go binary, JSON-RPC + WS + P2P + archive mode, MainNet default. Establishes the option shape and hardening matrix the remaining five service modules will mirror.

## Integration

The `klazomenai/autonity` flake is wired into `pkgs` via a `nixpkgs.overlays` entry on the glue repo's `nixosModules.default`:

```nix
nixosModules.default = {
  imports = [ ./modules ];
  nixpkgs.overlays = [
    (final: _prev: {
      autonity = autonity.packages.${final.stdenv.hostPlatform.system}.default;
      autonity-portable = autonity.packages.${final.stdenv.hostPlatform.system}.autonity-portable;
    })
  ];
};
```

So `pkgs.autonity` resolves to the minimal ELF variant and `pkgs.autonity-portable` to the bash-wrapped one. The module uses the standard `mkPackageOption pkgs "autonity" { }` idiom (per `CONTRIBUTING.md` and the rest of nixpkgs).

## Changes

- `modules/autonity.nix` — module with the full `services.autonity.*` option surface:
  - `enable`, `package` (`mkPackageOption pkgs "autonity" { }`), `dataDir`
  - `network` (enum mainnet/bakerloo, default mainnet), `syncMode` (default `full`), `gcMode` (default `archive` for Blockscout historical queries), `cache` (default 4096 MiB)
  - `http.{enable,addr,port,apis,vhosts}` — loopback-only defaults
  - `ws.{enable,addr,port,apis}` — loopback-only defaults
  - `p2p.{port,maxPeers,natExtIp,openFirewall}` — `port = 30303`, `openFirewall = true` wires `networking.firewall.allowed{TCP,UDP}Ports` (discovery + RLPx both need the same port)
  - `metrics.enable`, `bootnodes`, `extraArgs`
- **`dataDir` constraint**: `config.assertions` enforces the value lives under `/var/lib/` so `StateDirectory` (derived via `lib.removePrefix "/var/lib/"`) and `ProtectSystem = "strict"` stay consistent. Overriding `dataDir` now actually moves the systemd-managed directory + `--datadir` together.
- **CLI arguments** composed via `lib.cli.toGNUCommandLineShell` from a single attrset with `null`-value dropping, so flags only appear when their option is active. MainNet is upstream's default; only Bakerloo needs `--bakerloo`.
- **Defense-in-depth systemd hardening** per the `nix-modules-hardening` skill matrix:
  - `DynamicUser` + derived `StateDirectory` + `StateDirectoryMode = "0700"`
  - `ProtectSystem = "strict"`, `ProtectHome`, `PrivateTmp`, `PrivateDevices`, `PrivateUsers`, `PrivateMounts`, `ProcSubset = "pid"`, `ProtectProc = "invisible"`, `RemoveIPC`
  - `CapabilityBoundingSet = [ "" ]`, `NoNewPrivileges`, `LockPersonality`, `RestrictNamespaces`, `RestrictRealtime`, `RestrictSUIDSGID`
  - `MemoryDenyWriteExecute = true` — Go has no runtime JIT
  - `RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" "AF_NETLINK" ]` — AF_NETLINK required for go-ethereum-derived interface enumeration (NAT/discovery address selection); inline comment documents this
  - `SystemCallFilter = [ "~@cpu-emulation @debug @keyring @memlock @mount @obsolete @privileged @resources @setuid" ]`
  - `SystemCallArchitectures = "native"`, `UMask = "0077"`
- **`config.warnings`** fires loudly when an operator overrides `http.addr` or `ws.addr` to anything outside the loopback-safe set (`127.0.0.1`, `::1`, `localhost`), so beyond-loopback exposure is always a conscious decision.

## Round 1 review changes (commit `3791b8c`)

Six catches from Copilot, all adopted:

1. Swapped the `_module.args.autonityPkgs` wiring for a `nixpkgs.overlays` approach so the module can use `mkPackageOption` (per `CONTRIBUTING.md`).
2. Fixed the real `dataDir` / `StateDirectory` inconsistency via `config.assertions` + `lib.removePrefix`.
3. Rewrote the `dataDir` description to match the new behaviour honestly.
4. Added `p2p.openFirewall` + `networking.firewall` wiring; reworded "opens" → "configures Autonity to bind" on `p2p.port`.
5. Grammar fix in both warning strings: "in front of it" (was "front it").
6. Added `::1` (IPv6 loopback) to the loopback-safe set; factored the list into a `let loopbackSafe = ...` binding to avoid duplication.

## Test plan

- [x] `nix flake check --print-build-logs` passes locally on `x86_64-linux`
- [ ] `.github/workflows/flake-check.yml` runs green on this PR
- [ ] `nix eval .#nixosModules.default` evaluates cleanly (covered by flake check)
- [ ] Default bind on `http.addr` / `ws.addr` is `127.0.0.1` — verified in option defaults
- [ ] `dataDir` assertion triggers correctly for a `/srv/...` value
- [ ] `p2p.openFirewall = false` opts the service out of firewall modification
- [ ] Defense-in-depth matrix from `nix-modules-hardening` skill applied

Refs #4
