### PR TITLE
feat(nix): blockscout-postgresql wrapper module ⛵

### DIFF
--- a/modules/blockscout-postgresql.nix
+++ b/modules/blockscout-postgresql.nix
@@ -1,0 +1,103 @@
+# Thin wrapper over nixpkgs `services.postgresql` preconfiguring the
+# PostgreSQL database + role Blockscout expects, with UNIX-socket-only
+# binding as the default. Blockscout's backend connects via
+# `/run/postgresql/.s.PGSQL.5432` and joins the `postgres` group on its
+# own systemd unit (via `SupplementaryGroups`) for socket access.
+#
+# Hardening of `postgresql.service` itself is inherited from the
+# upstream nixpkgs module (static UID for on-disk permanence, full
+# defense-in-depth systemd block: `ProtectSystem = "strict"`,
+# `CapabilityBoundingSet = [""]`, narrow `RestrictAddressFamilies`,
+# `SystemCallFilter`, etc.) — this wrapper only adds the Blockscout-
+# specific surface on top. Re-applying or weakening that hardening is
+# deliberately avoided.
+{ config, lib, ... }:
+
+let
+  cfg = config.services.blockscout-postgresql;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    mkDefault
+    types
+    ;
+in
+{
+  options.services.blockscout-postgresql = {
+    enable = mkEnableOption "Blockscout's PostgreSQL (thin wrapper over services.postgresql)";
+
+    databaseName = mkOption {
+      type = types.str;
+      default = "blockscout";
+      description = ''
+        Name of the PostgreSQL database the Blockscout indexer and API
+        connect to. Created on first service start via
+        `services.postgresql.ensureDatabases`.
+      '';
+    };
+
+    username = mkOption {
+      type = types.str;
+      default = "blockscout";
+      description = ''
+        Name of the PostgreSQL role owning the Blockscout database.
+        Created on first service start via
+        `services.postgresql.ensureUsers` with
+        `ensureDBOwnership = true`. No password is set here — the
+        Blockscout backend module's `LoadCredential=` secrets pipeline
+        supplies the password at connection time.
+      '';
+    };
+
+    extraSettings = mkOption {
+      type = types.attrsOf (
+        types.oneOf [
+          types.bool
+          types.int
+          types.str
+        ]
+      );
+      default = { };
+      example = {
+        shared_buffers = "2GB";
+        work_mem = "64MB";
+      };
+      description = ''
+        Additional `postgresql.conf` settings merged into the underlying
+        `services.postgresql.settings` on top of this wrapper's
+        defaults. Operator-supplied values win over wrapper defaults.
+        Escape hatch for any setting this wrapper does not expose
+        directly.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    services.postgresql = {
+      enable = true;
+
+      ensureDatabases = [ cfg.databaseName ];
+      ensureUsers = [
+        {
+          name = cfg.username;
+          ensureDBOwnership = true;
+        }
+      ];
+
+      # UNIX-socket-only by default. Blockscout backend connects via
+      # /run/postgresql/.s.PGSQL.5432; joining the `postgres` group via
+      # SupplementaryGroups on its systemd unit grants socket access
+      # without needing a TCP listener or password. `mkDefault` so
+      # operators who genuinely need TCP (external monitoring, remote
+      # admin tools) can still override in their host config.
+      settings = {
+        listen_addresses = mkDefault "";
+        unix_socket_directories = mkDefault "/run/postgresql";
+        max_connections = mkDefault 250;
+        password_encryption = mkDefault "scram-sha-256";
+      }
+      // cfg.extraSettings;
+    };
+  };
+}

--- a/modules/blockscout-postgresql.nix
+++ b/modules/blockscout-postgresql.nix
@@ -44,9 +44,27 @@ in
         Name of the PostgreSQL role owning the Blockscout database.
         Created on first service start via
         `services.postgresql.ensureUsers` with
-        `ensureDBOwnership = true`. No password is set here — the
-        Blockscout backend module's `LoadCredential=` secrets pipeline
-        supplies the password at connection time.
+        `ensureDBOwnership = true`.
+
+        This wrapper does NOT set a role password and does NOT
+        configure `pg_hba.conf`. PostgreSQL authentication is a
+        separate concern from socket filesystem access and is left to
+        the consumer:
+
+        - The Blockscout backend module (upcoming PR) will either set
+          a role password from `LoadCredential=` at startup and add a
+          matching `scram-sha-256` entry in
+          `services.postgresql.authentication`, or configure a
+          `pg_ident.conf` username map if `peer` auth is preferred.
+        - Operators bypassing the backend module can configure
+          authentication themselves via
+          `services.postgresql.authentication`.
+
+        Nixpkgs' default `pg_hba.conf` uses `peer` auth for local
+        socket connections, which requires the OS username to match
+        the PostgreSQL role name — incompatible with the
+        `DynamicUser = true` pattern the backend uses (random OS
+        username per run), so additional wiring is always needed.
       '';
     };
 
@@ -85,12 +103,25 @@ in
         }
       ];
 
-      # UNIX-socket-only by default. Blockscout backend connects via
-      # /run/postgresql/.s.PGSQL.5432; joining the `postgres` group via
-      # SupplementaryGroups on its systemd unit grants socket access
-      # without needing a TCP listener or password. `mkDefault` so
-      # operators who genuinely need TCP (external monitoring, remote
-      # admin tools) can still override in their host config.
+      # UNIX-socket-only by default. Two independent layers are at
+      # play here; this wrapper handles only the first:
+      #   1. Socket FILESYSTEM access. /run/postgresql/.s.PGSQL.5432
+      #      is group-owned by `postgres`; consumers grant themselves
+      #      read/write access by joining that group via
+      #      SupplementaryGroups on their own systemd unit.
+      #   2. PostgreSQL AUTHENTICATION (pg_hba.conf). Controls whether
+      #      PostgreSQL trusts the connecting role once the socket has
+      #      been reached. Nixpkgs' default for `local` is `peer` — OS
+      #      username must match the PG role name — which breaks under
+      #      DynamicUser=true (random OS username). The Blockscout
+      #      backend module (or operator host config) must set up
+      #      either scram-sha-256 + a role password from LoadCredential,
+      #      or a pg_ident.conf username map. This wrapper deliberately
+      #      stays out of that second layer; see the upcoming
+      #      blockscout-backend module for the full auth wiring.
+      #
+      # `mkDefault` on each setting so operators who genuinely need TCP
+      # (external monitoring, remote admin tools) can override.
       settings = {
         listen_addresses = mkDefault "";
         unix_socket_directories = mkDefault "/run/postgresql";

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -14,8 +14,8 @@
 {
   imports = [
     ./autonity.nix
+    ./blockscout-postgresql.nix
     # Service modules land here as they ship:
-    #   ./blockscout-postgresql.nix
     #   ./blockscout-redis.nix
     #   ./blockscout-backend.nix
     #   ./blockscout-frontend.nix


### PR DESCRIPTION
## Summary

Second service module. Thin wrapper over nixpkgs `services.postgresql` that preconfigures the PostgreSQL database + role Blockscout expects and defaults to UNIX-socket-only binding. Backend connects via `/run/postgresql/.s.PGSQL.5432` and joins the `postgres` group on its own systemd unit (via `SupplementaryGroups`) for socket access — the pattern `CONTRIBUTING.md` mandates for cross-service UNIX-socket IPC.

## Design — thin wrapper, not a reimplementation

Hardening of `postgresql.service` itself is inherited from the upstream nixpkgs module (static UID for on-disk permanence, full defense-in-depth block including `ProtectSystem = "strict"`, empty `CapabilityBoundingSet`, narrow `RestrictAddressFamilies`, `SystemCallFilter`, etc.). This wrapper deliberately avoids re-applying or weakening that hardening — doing so would be a maintenance burden that tracks every nixpkgs security fix without adding Blockscout-specific value.

## Changes

- **`modules/blockscout-postgresql.nix`** (new, 100 lines) — option surface:
  - `enable` (`mkEnableOption`)
  - `databaseName` (default `"blockscout"`)
  - `username` (default `"blockscout"`)
  - `extraSettings` — `attrsOf (oneOf [ bool int str ])`, escape hatch for `postgresql.conf` values

  When `enable = true`:
  - `services.postgresql.enable = true;`
  - `services.postgresql.ensureDatabases = [ cfg.databaseName ];`
  - `services.postgresql.ensureUsers = [ { name = cfg.username; ensureDBOwnership = true; } ];`
  - `services.postgresql.settings` merged (via `lib.mkDefault` so operators can override):
    - `listen_addresses = ""` — UNIX-socket-only, no TCP listener
    - `unix_socket_directories = "/run/postgresql"` — standard nixpkgs location
    - `max_connections = 250` — headroom for Blockscout's pool + admin tooling
    - `password_encryption = "scram-sha-256"` — modern default
  - `extraSettings` merged on top, so operator-supplied values win over wrapper defaults

- **`modules/default.nix`** — imports `./blockscout-postgresql.nix` alongside the existing `./autonity.nix`.

No `package` option on the wrapper — operators wanting a specific PostgreSQL major set `services.postgresql.package` directly in their host config. No password set by the wrapper — the Blockscout backend module's `LoadCredential` pipeline will supply it at connection time.

## Test plan

- [x] `nix flake check --print-build-logs` passes locally on `x86_64-linux` (`checks.fmt` covers the new file via the find-based discovery shipped in #2)
- [ ] `.github/workflows/flake-check.yml` runs green on this PR
- [ ] `nix eval .#nixosModules.default` evaluates cleanly (covered by flake check's module-eval pass)
- [ ] Default `listen_addresses = ""` verified in option defaults
- [ ] Upstream `postgresql.service` hardening block unaffected — grep for any `systemd.services.postgresql` override in this PR returns zero hits
- [ ] `extraSettings` operator-supplied value wins over wrapper default (e.g. setting `max_connections = 500` via `extraSettings` overrides the `mkDefault 250`)

Refs #7
