### PR TITLE
feat(nix): blockscout-backend module with LoadCredential secrets 🔐

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,6 +23,29 @@
         "type": "github"
       }
     },
+    "blockscout": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776942568,
+        "narHash": "sha256-KIOu3HDPRaVRrkx6LEivkhL11VPkvw9anq2eZRIwgeY=",
+        "owner": "klazomenai",
+        "repo": "blockscout",
+        "rev": "69261addbe6137c3100707b4d027a760b070c3bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "klazomenai",
+        "repo": "blockscout",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -60,6 +83,7 @@
     "root": {
       "inputs": {
         "autonity": "autonity",
+        "blockscout": "blockscout",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,14 @@
     autonity.url = "github:klazomenai/autonity";
     autonity.inputs.nixpkgs.follows = "nixpkgs";
     autonity.inputs.flake-utils.follows = "flake-utils";
+
+    # Blockscout backend release (Elixir mixRelease) — produced by the
+    # `klazomenai/blockscout` fork's flake. The NixOS blockscout-backend
+    # module defaults `services.blockscout-backend.package` to
+    # `pkgs.blockscout`, wired via the nixpkgs.overlays entry below.
+    blockscout.url = "github:klazomenai/blockscout";
+    blockscout.inputs.nixpkgs.follows = "nixpkgs";
+    blockscout.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs =
@@ -23,6 +31,7 @@
       nixpkgs,
       flake-utils,
       autonity,
+      blockscout,
     }:
     let
       # Scope locked to x86_64-linux for the glue repo and all service
@@ -43,6 +52,7 @@
           (final: _prev: {
             autonity = autonity.packages.${final.stdenv.hostPlatform.system}.default;
             autonity-portable = autonity.packages.${final.stdenv.hostPlatform.system}.autonity-portable;
+            blockscout = blockscout.packages.${final.stdenv.hostPlatform.system}.default;
           })
         ];
       };

--- a/modules/blockscout-backend.nix
+++ b/modules/blockscout-backend.nix
@@ -42,18 +42,34 @@ let
     mkBefore
     types
     concatStringsSep
+    concatMapStringsSep
     mapAttrsToList
     optional
+    literalExpression
     ;
+
+  # Env-var-name regex — used to assert that every `secretEnvFiles`
+  # key is a valid POSIX env var name. Enforced at `config.assertions`
+  # time rather than via the submodule's `name` because submodule
+  # naming happens at a later pass in the module system; an assertion
+  # gives a clearer error message pointing at the exact offending key.
+  envVarNameRegex = "^[A-Z_][A-Z0-9_]*$";
 
   # Static env values — Nix-interpolated at module-eval time, written
   # verbatim into a Nix-store file by `pkgs.writeText`. Because Nix
   # produces the file content directly (not via `echo` inside a shell
   # script), values like `db$USER` or `db"quoted"` are stored as
   # literal characters — no bash expansion, no quote-closure risk.
-  # The file is world-readable in the Nix store; this is fine because
-  # it contains ZERO secrets — only configuration derived from module
-  # options that are already visible in the flake source.
+  #
+  # The file is world-readable in the Nix store. This is safe by
+  # convention: this module contracts that `extraEnv` carries no
+  # secrets. Secret-holding env vars (API keys, OAuth client secrets,
+  # SMTP credentials, etc.) go through `cfg.secretEnvFiles` instead —
+  # each value is ingested via `LoadCredential=` and appended at
+  # runtime, so it never touches the store. The contract is enforced
+  # via docs on `extraEnv` rather than a type-level check (operators
+  # are trusted; the surrounding deployment assumes operator
+  # awareness of Nix-store visibility).
   staticEnvFile = pkgs.writeText "blockscout-backend.env" (
     concatStringsSep "\n" (
       [
@@ -111,12 +127,18 @@ in
     };
 
     databaseName = mkOption {
-      type = types.str;
+      # SQL identifier regex — letters, digits, underscores, starting
+      # with a letter or underscore. Enforced at option-set time so
+      # the value can be safely interpolated into pg_hba.conf via
+      # services.postgresql.authentication below (rejects whitespace,
+      # newlines, quotes, and any other char that could inject an
+      # extra pg_hba rule).
+      type = types.strMatching "^[a-zA-Z_][a-zA-Z0-9_]*$";
       default = "blockscout";
     };
 
     databaseUser = mkOption {
-      type = types.str;
+      type = types.strMatching "^[a-zA-Z_][a-zA-Z0-9_]*$";
       default = "blockscout";
     };
 
@@ -253,11 +275,18 @@ in
         API_V2_ENABLED = "true";
       };
       description = ''
-        Additional environment variables passed to the backend.
+        Non-secret environment variables passed to the backend.
         Escape hatch for the 50+ Blockscout env vars this module does
         not expose as first-class options. Values must be strings —
         Blockscout's runtime-config layer treats all env vars as
         strings.
+
+        **Values MUST NOT be secrets.** `extraEnv` entries are
+        interpolated into a `pkgs.writeText`-backed file in the Nix
+        store, which is world-readable. For secret-holding env vars
+        (API keys, OAuth client secrets, SMTP credentials, Sentry
+        DSNs, etc.), use `secretEnvFiles` below — those are ingested
+        via systemd `LoadCredential=` and never land in the store.
 
         **Values MUST NOT contain newlines** — systemd's
         `EnvironmentFile` parser treats each newline as an entry
@@ -268,9 +297,63 @@ in
         `echo` that could expand them).
       '';
     };
+
+    secretEnvFiles = mkOption {
+      # Keys constrained to the env-var-name shape — letters, digits,
+      # underscores, starting with a letter or underscore, uppercase
+      # by convention (POSIX env vars). The key is used verbatim as
+      # both the `LoadCredential=` name and the filename under
+      # $CREDENTIALS_DIRECTORY, so unsafe characters would leak into
+      # those paths.
+      type = types.attrsOf (
+        types.submodule (
+          { name, ... }:
+          {
+            options.path = mkOption {
+              type = types.path;
+              description = "Absolute path to a file containing the value for env var `${name}`.";
+            };
+          }
+        )
+      );
+      default = { };
+      example = literalExpression ''
+        {
+          ACCOUNT_AUTH0_CLIENT_SECRET.path = "/run/secrets/blockscout/auth0_client_secret";
+          ETHERSCAN_API_KEY.path          = "/run/secrets/blockscout/etherscan_key";
+        }
+      '';
+      description = ''
+        Secret-holding environment variables whose values come from
+        files. Each entry's attribute name is the env var name (must
+        match `^[A-Z_][A-Z0-9_]*$`); `.path` is an absolute path to
+        the file containing its value.
+
+        Each file is ingested via systemd `LoadCredential=` at unit
+        start — the service reads the value from
+        `$CREDENTIALS_DIRECTORY/<NAME>`, never from the source path —
+        and appended to the runtime env file by an `ExecStartPre`
+        step. The value never lands in the Nix store.
+
+        Each file's contents must be a single line (no trailing
+        newline required; a single trailing `\n` is fine). Embedded
+        newlines will break the `EnvironmentFile` parser downstream.
+      '';
+    };
   };
 
   config = mkIf cfg.enable {
+    # Validate secretEnvFiles keys at option-set time. The key is used
+    # verbatim as both the LoadCredential= name and the
+    # $CREDENTIALS_DIRECTORY/<NAME> filename, so unsafe characters
+    # would leak into those paths. Checking via assertions rather than
+    # at the submodule level so the error message can name the exact
+    # offending key.
+    assertions = mapAttrsToList (name: _: {
+      assertion = builtins.match envVarNameRegex name != null;
+      message = "services.blockscout-backend.secretEnvFiles key `${name}` is not a valid POSIX env var name (must match `${envVarNameRegex}`).";
+    }) cfg.secretEnvFiles;
+
     # Local-socket `trust` authentication scoped to the specific role+
     # database. Rationale (databaseAuthRationale):
     #   - Socket filesystem access is already gated by the `postgres`
@@ -330,26 +413,29 @@ in
           "redis-${cfg.redisServerName}"
         ];
 
-        # Secret ingestion. systemd reads the source file as root at
+        # Secret ingestion. systemd reads each source file as root at
         # unit-start time and exposes the contents via
-        # $CREDENTIALS_DIRECTORY/secret_key_base — the DynamicUser
-        # UID never needs read access to the source path.
+        # $CREDENTIALS_DIRECTORY/<name> — the DynamicUser UID never
+        # needs read access to the source paths. `secret_key_base` is
+        # mandatory; everything under `secretEnvFiles` is optional
+        # operator-supplied (API keys, OAuth secrets, etc.).
         LoadCredential = [
           "secret_key_base:${cfg.secretKeyBaseFile}"
-        ];
+        ]
+        ++ mapAttrsToList (name: entry: "${name}:${entry.path}") cfg.secretEnvFiles;
 
         # ExecStartPre: compose $RUNTIME_DIRECTORY/env from the
-        # Nix-generated static env file + the secret read from
+        # Nix-generated static env file + all the secrets read from
         # $CREDENTIALS_DIRECTORY. EnvironmentFile= below reads the
         # composed file.
         #
         # Static values (DATABASE_URL, CHAIN_ID, extraEnv entries,
         # etc.) are interpolated at Nix-eval time into
         # `${staticEnvFile}` — no bash `echo` touches them, so no
-        # shell expansion / quote-closure risk. The one secret
-        # (SECRET_KEY_BASE) is appended at runtime from the
-        # credential tmpfs via `printf` + `cat`, which doesn't
-        # interpolate the value.
+        # shell expansion / quote-closure risk. Secrets
+        # (SECRET_KEY_BASE and every `secretEnvFiles` entry) are
+        # appended at runtime from the credential tmpfs via `printf`
+        # + `cat`, which does not interpolate the values.
         ExecStartPre = [
           (pkgs.writeShellScript "blockscout-compose-env" ''
             set -eu
@@ -359,15 +445,21 @@ in
             # runtime dir at 0600.
             install -m 0600 ${staticEnvFile} "$RUNTIME_DIRECTORY/env"
 
-            # Append the secret. `printf` + `cat` avoids shell
-            # expansion of the secret's contents; the credential
-            # file is expected to be a single line (operator
-            # responsibility — newlines break EnvironmentFile).
-            {
-              printf 'SECRET_KEY_BASE='
-              cat "$CREDENTIALS_DIRECTORY/secret_key_base"
-              printf '\n'
-            } >> "$RUNTIME_DIRECTORY/env"
+            # Append each secret. `printf` + `cat` avoids shell
+            # expansion of the secret contents; credential files are
+            # expected to be a single line (operator responsibility
+            # — embedded newlines would break EnvironmentFile).
+            append_secret() {
+              local key="$1"
+              {
+                printf '%s=' "$key"
+                cat "$CREDENTIALS_DIRECTORY/$key"
+                printf '\n'
+              } >> "$RUNTIME_DIRECTORY/env"
+            }
+
+            append_secret SECRET_KEY_BASE
+            ${concatMapStringsSep "\n" (name: "append_secret ${name}") (lib.attrNames cfg.secretEnvFiles)}
           '')
         ]
         ++ optional cfg.autoMigrate (

--- a/modules/blockscout-backend.nix
+++ b/modules/blockscout-backend.nix
@@ -101,7 +101,12 @@ in
     package = mkPackageOption pkgs "blockscout" { };
 
     secretKeyBaseFile = mkOption {
-      type = types.path;
+      # types.str (not types.path) by design — Nix-path literals
+      # (`./secret`) auto-copy into the world-readable /nix/store,
+      # defeating the module's secrets contract. `types.str` accepts
+      # path strings as-is; `config.assertions` below additionally
+      # enforces that the value is absolute and not under /nix/store/.
+      type = types.str;
       example = "/run/secrets/blockscout/secret_key_base";
       description = ''
         Absolute path to a file containing Phoenix `secret_key_base` —
@@ -112,6 +117,12 @@ in
         source path. The file only needs to be readable by systemd
         (root at unit-start time), not by the `DynamicUser`-allocated
         UID.
+
+        MUST be an absolute path NOT under `/nix/store/` — the
+        module's secrets contract is that values never appear in the
+        world-readable Nix store, so accidentally pointing this at a
+        store path is a configuration error. Enforced via
+        `config.assertions` at option-set time.
       '';
     };
 
@@ -136,11 +147,26 @@ in
       # extra pg_hba rule).
       type = types.strMatching "^[a-zA-Z_][a-zA-Z0-9_]*$";
       default = "blockscout";
+      description = ''
+        PostgreSQL database the Blockscout backend reads and writes.
+        Must match the `databaseName` configured on the
+        `blockscout-postgresql` wrapper (both default to
+        `"blockscout"` — override either side and you must align the
+        other manually).
+      '';
     };
 
     databaseUser = mkOption {
       type = types.strMatching "^[a-zA-Z_][a-zA-Z0-9_]*$";
       default = "blockscout";
+      description = ''
+        PostgreSQL role the Blockscout backend connects as. Must
+        match the `username` configured on the `blockscout-postgresql`
+        wrapper (both default to `"blockscout"`). Used verbatim in
+        the generated `services.postgresql.authentication` stanza,
+        so the `types.strMatching` regex forbids any character that
+        could inject an extra pg_hba rule.
+      '';
     };
 
     redisServerName = mkOption {
@@ -269,6 +295,33 @@ in
       '';
     };
 
+    configurePostgresAuth = mkOption {
+      type = types.nullOr types.bool;
+      default = null;
+      description = ''
+        Whether this module should prepend a
+        `local ${"\${databaseName}"} ${"\${databaseUser}"} trust` rule to
+        `services.postgresql.authentication`.
+
+        - `null` (default): auto-detect from `databaseHost` — inject
+          the rule only when `databaseHost` is an absolute path (a
+          UNIX socket directory, which is where the rule applies).
+        - `true`: always inject (useful if the operator configures
+          PostgreSQL themselves but still wants this module's pg_hba
+          management).
+        - `false`: never inject — the operator will configure
+          `services.postgresql.authentication` themselves. Appropriate
+          when `databaseHost` is a TCP host (remote PostgreSQL) or
+          when the operator wants password auth instead of local
+          `trust`.
+
+        The auto-detect default avoids a historical bug where the
+        module unconditionally modified the local PostgreSQL's
+        pg_hba.conf even when `databaseHost` pointed at a TCP
+        hostname, weakening an unrelated local PG instance.
+      '';
+    };
+
     extraEnv = mkOption {
       type = types.attrsOf types.str;
       default = { };
@@ -306,8 +359,18 @@ in
           { name, ... }:
           {
             options.path = mkOption {
-              type = types.path;
-              description = "Absolute path to a file containing the value for env var `${name}`.";
+              # types.str (not types.path) — same rationale as
+              # `secretKeyBaseFile`: Nix-path literals would auto-copy
+              # into the world-readable /nix/store and defeat the
+              # secrets contract. Absolute-not-in-store is enforced
+              # via `config.assertions` at the module level so the
+              # error message names the offending key.
+              type = types.str;
+              description = ''
+                Absolute path (NOT under `/nix/store/`) to a file
+                containing the value for env var `${name}`. Enforced
+                via `config.assertions` at option-set time.
+              '';
             };
           }
         )
@@ -342,19 +405,46 @@ in
   };
 
   config = mkIf cfg.enable {
-    # Validate secretEnvFiles keys at option-set time. The key is used
-    # verbatim as both the LoadCredential= name and the
-    # $CREDENTIALS_DIRECTORY/<NAME> filename, so unsafe characters
-    # would leak into those paths. Checking via assertions rather than
-    # at the submodule level so the error message can name the exact
-    # offending key.
-    assertions = mapAttrsToList (name: _: {
-      assertion = builtins.match envVarNameRegex name != null;
-      message = "services.blockscout-backend.secretEnvFiles key `${name}` is not a valid POSIX env var name (must match `${envVarNameRegex}`).";
-    }) cfg.secretEnvFiles;
+    # Validate:
+    #   1. secretEnvFiles keys are valid POSIX env var names. The key
+    #      is used verbatim as both the LoadCredential= name and the
+    #      $CREDENTIALS_DIRECTORY/<NAME> filename, so unsafe chars
+    #      would leak into those paths.
+    #   2. Every secret path option (secretKeyBaseFile and each
+    #      secretEnvFiles.<name>.path) is absolute and NOT under
+    #      /nix/store/. The store is world-readable; letting a secret
+    #      path resolve there (e.g. via a Nix-path literal like
+    #      `./secret`) would silently defeat this module's secrets
+    #      contract. Assertions give a clearer error than a type check
+    #      because the message can name the exact offending option.
+    assertions =
+      (mapAttrsToList (name: _: {
+        assertion = builtins.match envVarNameRegex name != null;
+        message = "services.blockscout-backend.secretEnvFiles key `${name}` is not a valid POSIX env var name (must match `${envVarNameRegex}`).";
+      }) cfg.secretEnvFiles)
+      ++ [
+        {
+          assertion =
+            lib.hasPrefix "/" cfg.secretKeyBaseFile && !lib.hasPrefix "/nix/store/" cfg.secretKeyBaseFile;
+          message = "services.blockscout-backend.secretKeyBaseFile (`${cfg.secretKeyBaseFile}`) must be an absolute path NOT under /nix/store/. Storing secrets in the world-readable Nix store defeats the module's secrets contract.";
+        }
+      ]
+      ++ mapAttrsToList (name: entry: {
+        assertion = lib.hasPrefix "/" entry.path && !lib.hasPrefix "/nix/store/" entry.path;
+        message = "services.blockscout-backend.secretEnvFiles.${name}.path (`${entry.path}`) must be an absolute path NOT under /nix/store/. Storing secrets in the world-readable Nix store defeats the module's secrets contract.";
+      }) cfg.secretEnvFiles;
 
     # Local-socket `trust` authentication scoped to the specific role+
-    # database. Rationale (databaseAuthRationale):
+    # database — only injected when `configurePostgresAuth` resolves
+    # to true. Default auto-detect gates on `databaseHost` being an
+    # absolute path (UNIX socket directory): if the operator has
+    # pointed `databaseHost` at a TCP host, the `local` pg_hba rule
+    # would apply to an unrelated local PostgreSQL and could silently
+    # weaken its auth posture. Explicit override via
+    # `configurePostgresAuth = true/false` when the heuristic is
+    # wrong for the deployment.
+    #
+    # Rationale (databaseAuthRationale) when the rule IS installed:
     #   - Socket filesystem access is already gated by the `postgres`
     #     group. Only services joining that group via
     #     SupplementaryGroups can reach /run/postgresql/.s.PGSQL.5432
@@ -373,9 +463,17 @@ in
     # services.postgresql.authentication themselves and add a
     # password-sync mechanism; see the `username` description on
     # services.blockscout-postgresql for the two realistic paths.
-    services.postgresql.authentication = mkBefore ''
-      local ${cfg.databaseName} ${cfg.databaseUser} trust
-    '';
+    services.postgresql.authentication =
+      let
+        effective =
+          if cfg.configurePostgresAuth != null then
+            cfg.configurePostgresAuth
+          else
+            lib.hasPrefix "/" cfg.databaseHost;
+      in
+      mkIf effective (mkBefore ''
+        local ${cfg.databaseName} ${cfg.databaseUser} trust
+      '');
 
     systemd.services.blockscout-backend = {
       description = "Blockscout Elixir/Phoenix backend (API + indexer)";

--- a/modules/blockscout-backend.nix
+++ b/modules/blockscout-backend.nix
@@ -157,11 +157,32 @@ in
       type = types.str;
       default = "/run/postgresql";
       description = ''
-        PostgreSQL socket directory — the value passed as `host=` in
-        the libpq connection string. Defaults to the standard nixpkgs
-        location used by the `blockscout-postgresql` wrapper. Not a
-        hostname: an absolute path to the directory containing
-        `.s.PGSQL.<port>`.
+        PostgreSQL `host=` value for the libpq connection string.
+        Supports either:
+
+        - an absolute path to a Unix-domain socket directory
+          containing `.s.PGSQL.<port>` (for example
+          `"/run/postgresql"`, the standard nixpkgs location used by
+          the `blockscout-postgresql` wrapper); or
+        - a TCP hostname or address (for example `"localhost"` or a
+          remote PostgreSQL host).
+
+        When this is a socket directory, the connection uses the local
+        PostgreSQL Unix socket, the systemd unit gains an `after` /
+        `requires` dependency on `postgresql.service`,
+        `SupplementaryGroups` includes `"postgres"` for socket access,
+        and `services.postgresql.authentication` gets a `local
+        <db> <user> trust` rule (gated on `configurePostgresAuth`).
+
+        When this is a TCP hostname/address, the connection uses TCP
+        and none of the local-PG assumptions apply: no local
+        `postgresql.service` dependency, no `postgres`
+        SupplementaryGroup, no pg_hba injection. The operator is
+        responsible for ensuring the target PostgreSQL is reachable
+        and configured to authenticate `${cfg.databaseUser}` on
+        `${cfg.databaseName}` however they prefer (password,
+        certificate, SCRAM, etc.) — see `secretEnvFiles` for wiring
+        a `PGPASSWORD` or similar.
       '';
     };
 

--- a/modules/blockscout-backend.nix
+++ b/modules/blockscout-backend.nix
@@ -1,0 +1,409 @@
+# NixOS service module for the Blockscout backend (Elixir/Phoenix API
+# + indexer). This is the cross-service module where the plumbing
+# established by autonity.nix, blockscout-postgresql.nix, and
+# blockscout-redis.nix finally comes together.
+#
+# Cross-service contract:
+#   - PostgreSQL: connects via UNIX socket /run/postgresql/.s.PGSQL.5432
+#     (joining the `postgres` group via SupplementaryGroups for socket
+#     filesystem access). Authentication: local `trust` auth scoped to
+#     the specific role+database via services.postgresql.authentication
+#     (mkBefore) — socket access is the auth boundary on a single-
+#     machine deployment; see the `databaseAuthRationale` comment below.
+#   - Redis: connects via UNIX socket /run/redis-<name>/redis.sock
+#     (joining the `redis-<name>` group via SupplementaryGroups). Redis
+#     has no authentication configured; socket access is the auth
+#     boundary.
+#   - Autonity: connects via loopback TCP to 127.0.0.1:8545 (http),
+#     8546 (ws); the Autonity module binds loopback-only on those
+#     ports by default.
+#   - Secrets: Phoenix `secret_key_base` ingested via systemd
+#     `LoadCredential=` so the service never reads the source file
+#     directly; composed into $RUNTIME_DIRECTORY/env by ExecStartPre
+#     and read back via EnvironmentFile.
+#
+# The `klazomenai/blockscout` flake is wired into pkgs via a
+# nixpkgs.overlays entry on the glue-repo's nixosModules.default (see
+# ../flake.nix), so `pkgs.blockscout` resolves to the mixRelease.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.blockscout-backend;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    mkIf
+    mkBefore
+    types
+    concatMapStrings
+    attrNames
+    optional
+    ;
+in
+{
+  options.services.blockscout-backend = {
+    enable = mkEnableOption "the Blockscout Elixir/Phoenix backend (API + indexer)";
+
+    package = mkPackageOption pkgs "blockscout" { };
+
+    secretKeyBaseFile = mkOption {
+      type = types.path;
+      example = "/run/secrets/blockscout/secret_key_base";
+      description = ''
+        Absolute path to a file containing Phoenix `secret_key_base` —
+        64+ bytes of random used to sign user sessions and verify CSRF
+        tokens. Ingested via systemd `LoadCredential=`; the service
+        reads from `$CREDENTIALS_DIRECTORY/secret_key_base`, never
+        from this source path. The file only needs to be readable by
+        systemd (root at unit-start time), not by the `DynamicUser`-
+        allocated UID.
+      '';
+    };
+
+    databaseHost = mkOption {
+      type = types.str;
+      default = "/run/postgresql";
+      description = ''
+        PostgreSQL socket directory — the value passed as `host=` in
+        the libpq connection string. Defaults to the standard nixpkgs
+        location used by the `blockscout-postgresql` wrapper. Not a
+        hostname: an absolute path to the directory containing
+        `.s.PGSQL.<port>`.
+      '';
+    };
+
+    databaseName = mkOption {
+      type = types.str;
+      default = "blockscout";
+    };
+
+    databaseUser = mkOption {
+      type = types.str;
+      default = "blockscout";
+    };
+
+    redisServerName = mkOption {
+      type = types.strMatching "^[a-z0-9][a-z0-9_-]*$";
+      default = "blockscout";
+      description = ''
+        Name of the `services.blockscout-redis.serverName` this
+        backend talks to. Drives both the group the backend joins via
+        `SupplementaryGroups = [ "redis-<name>" ]` and the socket
+        path it connects to (`/run/redis-<name>/redis.sock`). Must
+        match `services.blockscout-redis.serverName` (enforced on
+        both sides via the same `types.strMatching` regex).
+      '';
+    };
+
+    ethereumRpc = {
+      httpUrl = mkOption {
+        type = types.str;
+        default = "http://127.0.0.1:8545";
+        description = ''
+          URL the backend indexer + API use for JSON-RPC calls.
+          Defaults to loopback Autonity.
+        '';
+      };
+      wsUrl = mkOption {
+        type = types.str;
+        default = "ws://127.0.0.1:8546";
+      };
+      traceUrl = mkOption {
+        type = types.str;
+        default = "http://127.0.0.1:8545";
+        description = ''
+          URL for `debug_traceTransaction` calls. Blockscout requires
+          the target Ethereum node to run in archive mode — the
+          autonity module ships with `gcMode = "archive"` by default.
+        '';
+      };
+    };
+
+    chain = {
+      id = mkOption {
+        type = types.ints.positive;
+        default = 65000000;
+        description = "Chain ID. Default is Autonity MainNet.";
+      };
+      coin = mkOption {
+        type = types.str;
+        default = "ATN";
+      };
+      coinName = mkOption {
+        type = types.str;
+        default = "Auton";
+      };
+      network = mkOption {
+        type = types.str;
+        default = "Autonity";
+      };
+      subnetwork = mkOption {
+        type = types.str;
+        default = "MainNet";
+      };
+    };
+
+    http = {
+      port = mkOption {
+        type = types.port;
+        default = 4000;
+        description = ''
+          TCP port the backend's Phoenix endpoint binds. The nginx
+          reverse proxy (`blockscout-nginx` module, later PR) is
+          expected to terminate TLS and forward to this port.
+        '';
+      };
+      bindAddress = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = ''
+          Listen address for the backend Phoenix endpoint. Defaults
+          to loopback — nginx reverse-proxies from the same host.
+          Overriding to a non-loopback value triggers a warning.
+        '';
+      };
+      host = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = ''
+          `BLOCKSCOUT_HOST` — the hostname the backend advertises to
+          the frontend and emits in generated URLs. Defaults to
+          `localhost` for smoke testing; in production this should
+          be the public domain served through nginx.
+        '';
+      };
+      protocol = mkOption {
+        type = types.enum [
+          "http"
+          "https"
+        ];
+        default = "http";
+        description = ''
+          `BLOCKSCOUT_PROTOCOL`. Stays `http` at the backend layer
+          because TLS terminates at the nginx reverse proxy; only
+          set to `https` when the backend is reached directly over
+          TLS.
+        '';
+      };
+    };
+
+    autoMigrate = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Run `Explorer.Release.migrate()` as an `ExecStartPre` before
+        each service start. Idempotent — running against an already-
+        migrated database is a no-op. Disable only if migrations are
+        orchestrated externally (e.g. a separate admin tool).
+      '';
+    };
+
+    extraEnv = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        ACCOUNT_ENABLED = "false";
+        DISABLE_INDEXER = "false";
+        API_V2_ENABLED = "true";
+      };
+      description = ''
+        Additional environment variables passed to the backend.
+        Escape hatch for the 50+ Blockscout env vars this module does
+        not expose as first-class options. Values must be strings —
+        Blockscout's runtime-config layer treats all env vars as
+        strings.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Local-socket `trust` authentication scoped to the specific role+
+    # database. Rationale (databaseAuthRationale):
+    #   - Socket filesystem access is already gated by the `postgres`
+    #     group. Only services joining that group via
+    #     SupplementaryGroups can reach /run/postgresql/.s.PGSQL.5432
+    #     at all — in this stack, that's blockscout-backend and
+    #     nothing else.
+    #   - Once the socket is reached, the role scope limits access to
+    #     the blockscout database + role.
+    #   - Password-based auth would add a layer, but the password
+    #     would have to be readable to the same process that already
+    #     has socket access — same blast radius.
+    #   - mkBefore puts this entry ahead of nixpkgs' default
+    #     `local all all peer`, so the scoped `trust` rule matches
+    #     first and the broader `peer` rule is never reached for this
+    #     role+database combination.
+    # Operators needing stronger auth can override
+    # services.postgresql.authentication themselves and add a
+    # password-sync mechanism; see the `username` description on
+    # services.blockscout-postgresql for the two realistic paths.
+    services.postgresql.authentication = mkBefore ''
+      local ${cfg.databaseName} ${cfg.databaseUser} trust
+    '';
+
+    systemd.services.blockscout-backend = {
+      description = "Blockscout Elixir/Phoenix backend (API + indexer)";
+      after = [
+        "network-online.target"
+        "postgresql.service"
+        "redis-${cfg.redisServerName}.service"
+      ];
+      wants = [ "network-online.target" ];
+      requires = [
+        "postgresql.service"
+        "redis-${cfg.redisServerName}.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/blockscout start";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        DynamicUser = true;
+        StateDirectory = "blockscout-backend";
+        StateDirectoryMode = "0700";
+        RuntimeDirectory = "blockscout-backend";
+        RuntimeDirectoryMode = "0700";
+
+        # Cross-service UNIX socket access. `postgres` and
+        # `redis-<name>` groups are auto-created by the respective
+        # upstream modules; joining them here grants filesystem
+        # access to /run/postgresql/.s.PGSQL.5432 and
+        # /run/redis-<name>/redis.sock respectively.
+        SupplementaryGroups = [
+          "postgres"
+          "redis-${cfg.redisServerName}"
+        ];
+
+        # Secret ingestion. systemd reads the source file as root at
+        # unit-start time and exposes the contents via
+        # $CREDENTIALS_DIRECTORY/secret_key_base — the DynamicUser
+        # UID never needs read access to the source path.
+        LoadCredential = [
+          "secret_key_base:${cfg.secretKeyBaseFile}"
+        ];
+
+        # ExecStartPre: compose $RUNTIME_DIRECTORY/env from the
+        # credential + config options. EnvironmentFile below reads
+        # that composed file, so the secret never appears in the
+        # unit file or anywhere in the Nix store.
+        ExecStartPre = [
+          (pkgs.writeShellScript "blockscout-compose-env" ''
+            set -eu
+            umask 077
+
+            secret_key_base=$(cat "$CREDENTIALS_DIRECTORY/secret_key_base")
+
+            {
+              echo "DATABASE_URL=postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}"
+              echo "ACCOUNT_DATABASE_URL=postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}"
+              echo "SECRET_KEY_BASE=$secret_key_base"
+
+              echo "ACCOUNT_REDIS_URL=unix:///run/redis-${cfg.redisServerName}/redis.sock"
+
+              echo "ETHEREUM_JSONRPC_VARIANT=geth"
+              echo "ETHEREUM_JSONRPC_HTTP_URL=${cfg.ethereumRpc.httpUrl}"
+              echo "ETHEREUM_JSONRPC_WS_URL=${cfg.ethereumRpc.wsUrl}"
+              echo "ETHEREUM_JSONRPC_TRACE_URL=${cfg.ethereumRpc.traceUrl}"
+
+              echo "CHAIN_ID=${toString cfg.chain.id}"
+              echo "COIN=${cfg.chain.coin}"
+              echo "COIN_NAME=${cfg.chain.coinName}"
+              echo "NETWORK=${cfg.chain.network}"
+              echo "SUBNETWORK=${cfg.chain.subnetwork}"
+
+              echo "PORT=${toString cfg.http.port}"
+              echo "BLOCKSCOUT_HOST=${cfg.http.host}"
+              echo "BLOCKSCOUT_PROTOCOL=${cfg.http.protocol}"
+
+              ${concatMapStrings (name: ''
+                echo "${name}=${cfg.extraEnv.${name}}"
+              '') (attrNames cfg.extraEnv)}
+            } > "$RUNTIME_DIRECTORY/env"
+          '')
+        ]
+        ++ optional cfg.autoMigrate (
+          "!"
+          + toString (
+            pkgs.writeShellScript "blockscout-migrate" ''
+              set -eu
+              # Source the env file composed above so the migration
+              # script sees DATABASE_URL, SECRET_KEY_BASE, etc.
+              set -a
+              . "$RUNTIME_DIRECTORY/env"
+              set +a
+              exec ${cfg.package}/bin/blockscout eval 'Explorer.Release.migrate()'
+            ''
+          )
+        );
+
+        # Use the systemd %t runtime-dir expansion so the path is
+        # correct regardless of whether the service runs with or
+        # without DynamicUser.
+        EnvironmentFile = [ "-%t/blockscout-backend/env" ];
+
+        # BEAM JIT needs writable + executable memory pages — opt out
+        # of MemoryDenyWriteExecute. Per the nix-modules-hardening
+        # skill's JIT exception list. Go, Rust, and non-JIT runtimes
+        # keep the default `true`.
+        MemoryDenyWriteExecute = false;
+
+        # Defense-in-depth hardening per the nix-modules-hardening
+        # skill matrix.
+        CapabilityBoundingSet = [ "" ];
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        # No AF_NETLINK — the backend does not enumerate interfaces
+        # or read routing information.
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@cpu-emulation @debug @keyring @memlock @mount @obsolete @privileged @resources @setuid"
+        ];
+        UMask = "0077";
+      };
+    };
+
+    # Loud warning on non-loopback bindAddress. Same pattern as the
+    # autonity module: exposure should be a conscious choice.
+    warnings =
+      let
+        loopbackSafe = [
+          "127.0.0.1"
+          "::1"
+          "localhost"
+        ];
+      in
+      optional (!builtins.elem cfg.http.bindAddress loopbackSafe)
+        "services.blockscout-backend.http.bindAddress is `${cfg.http.bindAddress}` — the backend API will be reachable beyond loopback. Ensure nginx TLS termination and an auth gate are in front of it (the blockscout-nginx module handles this by default).";
+  };
+}

--- a/modules/blockscout-backend.nix
+++ b/modules/blockscout-backend.nix
@@ -4,12 +4,19 @@
 # blockscout-redis.nix finally comes together.
 #
 # Cross-service contract:
-#   - PostgreSQL: connects via UNIX socket /run/postgresql/.s.PGSQL.5432
-#     (joining the `postgres` group via SupplementaryGroups for socket
-#     filesystem access). Authentication: local `trust` auth scoped to
-#     the specific role+database via services.postgresql.authentication
-#     (mkBefore) — socket access is the auth boundary on a single-
-#     machine deployment; see the `databaseAuthRationale` comment below.
+#   - PostgreSQL (default: local UNIX socket): connects via
+#     /run/postgresql/.s.PGSQL.5432, joining the `postgres` group via
+#     SupplementaryGroups for socket filesystem access. Authentication:
+#     local `trust` scoped to the specific role+database via
+#     services.postgresql.authentication (mkBefore) — socket access is
+#     the auth boundary on a single-machine deployment; see the
+#     `databaseAuthRationale` comment below.
+#     If `databaseHost` is set to a TCP hostname, the module detects
+#     this (no leading `/`) and skips ALL local-PG assumptions: no
+#     `postgresql.service` dependency, no `postgres` SupplementaryGroup,
+#     no pg_hba.conf injection. `configurePostgresAuth` lets operators
+#     override the pg_hba-injection heuristic when the deployment shape
+#     is unusual.
 #   - Redis: connects via UNIX socket /run/redis-<name>/redis.sock
 #     (joining the `redis-<name>` group via SupplementaryGroups). Redis
 #     has no authentication configured; socket access is the auth
@@ -51,6 +58,7 @@ let
     types
     concatMapStringsSep
     mapAttrsToList
+    optional
     optionalString
     literalExpression
     ;
@@ -61,6 +69,25 @@ let
   # naming happens at a later pass in the module system; an assertion
   # gives a clearer error message pointing at the exact offending key.
   envVarNameRegex = "^[A-Z_][A-Z0-9_]*$";
+
+  # Derived fact: whether `databaseHost` points at a UNIX socket
+  # directory (absolute path starting with `/`). Used as the single
+  # source of truth for "is the PostgreSQL we talk to running locally
+  # and reachable by socket?" — gates four places consistently:
+  #   1. `services.postgresql.authentication` pg_hba injection
+  #      (operator can still override via `configurePostgresAuth`)
+  #   2. `systemd.services.blockscout-backend.after` dependency on
+  #      `postgresql.service`
+  #   3. …`requires` on `postgresql.service`
+  #   4. `SupplementaryGroups = [ "postgres" ]` — only needed for
+  #      UNIX-socket filesystem access; harmless for TCP but
+  #      references a group that doesn't exist without local PG
+  #
+  # TCP hosts (remote PG) → all four are skipped, so the module can
+  # be pointed at a remote PostgreSQL without dragging in a local
+  # `postgresql.service` dependency or a non-existent `postgres`
+  # group.
+  postgresLocal = lib.hasPrefix "/" cfg.databaseHost;
 
   # Bash wrapper that exports each LoadCredential-sourced secret into
   # the process environment, optionally runs the migration, then execs
@@ -465,11 +492,7 @@ in
     # services.blockscout-postgresql for the two realistic paths.
     services.postgresql.authentication =
       let
-        effective =
-          if cfg.configurePostgresAuth != null then
-            cfg.configurePostgresAuth
-          else
-            lib.hasPrefix "/" cfg.databaseHost;
+        effective = if cfg.configurePostgresAuth != null then cfg.configurePostgresAuth else postgresLocal;
       in
       mkIf effective (mkBefore ''
         local ${cfg.databaseName} ${cfg.databaseUser} trust
@@ -479,14 +502,14 @@ in
       description = "Blockscout Elixir/Phoenix backend (API + indexer)";
       after = [
         "network-online.target"
-        "postgresql.service"
         "redis-${cfg.redisServerName}.service"
-      ];
+      ]
+      ++ optional postgresLocal "postgresql.service";
       wants = [ "network-online.target" ];
       requires = [
-        "postgresql.service"
         "redis-${cfg.redisServerName}.service"
-      ];
+      ]
+      ++ optional postgresLocal "postgresql.service";
       wantedBy = [ "multi-user.target" ];
 
       # Static (non-secret) env — systemd emits these as `Environment=`
@@ -536,10 +559,14 @@ in
         # upstream modules; joining them here grants filesystem
         # access to /run/postgresql/.s.PGSQL.5432 and
         # /run/redis-<name>/redis.sock respectively.
+        #
+        # `postgres` is only added when `databaseHost` points at a
+        # UNIX socket (`postgresLocal`); for TCP remote PG we skip
+        # the group since it may not exist on the host at all.
         SupplementaryGroups = [
-          "postgres"
           "redis-${cfg.redisServerName}"
-        ];
+        ]
+        ++ optional postgresLocal "postgres";
 
         # Secret ingestion. systemd reads each source file as root at
         # unit-start time and exposes the contents via

--- a/modules/blockscout-backend.nix
+++ b/modules/blockscout-backend.nix
@@ -17,10 +17,18 @@
 #   - Autonity: connects via loopback TCP to 127.0.0.1:8545 (http),
 #     8546 (ws); the Autonity module binds loopback-only on those
 #     ports by default.
-#   - Secrets: Phoenix `secret_key_base` ingested via systemd
-#     `LoadCredential=` so the service never reads the source file
-#     directly; composed into $RUNTIME_DIRECTORY/env by ExecStartPre
-#     and read back via EnvironmentFile.
+#   - Secrets: every secret-holding env var (SECRET_KEY_BASE plus each
+#     `secretEnvFiles` entry) is ingested via systemd `LoadCredential=`
+#     — the service reads each value from `$CREDENTIALS_DIRECTORY/<NAME>`
+#     at ExecStart time and `export`s it into the process environment
+#     via the `blockscout-start` shell wrapper. Secret values never
+#     touch the Nix store, EnvironmentFile, or the unit file.
+#   - Static env: passed via `systemd.services.*.environment` (direct
+#     systemd `Environment=` entries), not via an EnvironmentFile. This
+#     side-steps the EnvironmentFile mechanism's unit-start-time load
+#     ordering (EnvironmentFile is read BEFORE ExecStartPre, so a
+#     dynamically-composed env file wouldn't be seen) and its format /
+#     shell-parsing ambiguity.
 #
 # The `klazomenai/blockscout` flake is wired into pkgs via a
 # nixpkgs.overlays entry on the glue-repo's nixosModules.default (see
@@ -41,10 +49,9 @@ let
     mkIf
     mkBefore
     types
-    concatStringsSep
     concatMapStringsSep
     mapAttrsToList
-    optional
+    optionalString
     literalExpression
     ;
 
@@ -55,44 +62,37 @@ let
   # gives a clearer error message pointing at the exact offending key.
   envVarNameRegex = "^[A-Z_][A-Z0-9_]*$";
 
-  # Static env values — Nix-interpolated at module-eval time, written
-  # verbatim into a Nix-store file by `pkgs.writeText`. Because Nix
-  # produces the file content directly (not via `echo` inside a shell
-  # script), values like `db$USER` or `db"quoted"` are stored as
-  # literal characters — no bash expansion, no quote-closure risk.
+  # Bash wrapper that exports each LoadCredential-sourced secret into
+  # the process environment, optionally runs the migration, then execs
+  # the main server. Static env vars are provided by systemd's
+  # `Environment=` mechanism (see `systemd.services.*.environment`
+  # below); only secrets flow through this wrapper.
   #
-  # The file is world-readable in the Nix store. This is safe by
-  # convention: this module contracts that `extraEnv` carries no
-  # secrets. Secret-holding env vars (API keys, OAuth client secrets,
-  # SMTP credentials, etc.) go through `cfg.secretEnvFiles` instead —
-  # each value is ingested via `LoadCredential=` and appended at
-  # runtime, so it never touches the store. The contract is enforced
-  # via docs on `extraEnv` rather than a type-level check (operators
-  # are trusted; the surrounding deployment assumes operator
-  # awareness of Nix-store visibility).
-  staticEnvFile = pkgs.writeText "blockscout-backend.env" (
-    concatStringsSep "\n" (
-      [
-        "DATABASE_URL=postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}"
-        "ACCOUNT_DATABASE_URL=postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}"
-        "ACCOUNT_REDIS_URL=unix:///run/redis-${cfg.redisServerName}/redis.sock"
-        "ETHEREUM_JSONRPC_VARIANT=geth"
-        "ETHEREUM_JSONRPC_HTTP_URL=${cfg.ethereumRpc.httpUrl}"
-        "ETHEREUM_JSONRPC_WS_URL=${cfg.ethereumRpc.wsUrl}"
-        "ETHEREUM_JSONRPC_TRACE_URL=${cfg.ethereumRpc.traceUrl}"
-        "CHAIN_ID=${toString cfg.chain.id}"
-        "COIN=${cfg.chain.coin}"
-        "COIN_NAME=${cfg.chain.coinName}"
-        "NETWORK=${cfg.chain.network}"
-        "SUBNETWORK=${cfg.chain.subnetwork}"
-        "PORT=${toString cfg.http.port}"
-        "BLOCKSCOUT_HOST=${cfg.http.host}"
-        "BLOCKSCOUT_PROTOCOL=${cfg.http.protocol}"
-      ]
-      ++ mapAttrsToList (k: v: "${k}=${v}") cfg.extraEnv
-    )
-    + "\n"
-  );
+  # Why a wrapper rather than an EnvironmentFile? EnvironmentFile is
+  # loaded by systemd at unit activation, BEFORE any ExecStartPre runs
+  # — so an env file composed during ExecStartPre would never be seen
+  # by ExecStart. The wrapper reads credentials at the moment
+  # ExecStart fires, which is the only reliable point by which
+  # LoadCredential has populated $CREDENTIALS_DIRECTORY.
+  startScript = pkgs.writeShellScript "blockscout-start" ''
+    set -eu
+
+    # $(cat …) captures the credential file's bytes verbatim. Bash
+    # variable assignment does not re-expand `$` / backticks in the
+    # value, so secrets containing shell metacharacters are preserved
+    # literally. Each credential file is expected to contain a single
+    # value with no trailing content beyond an optional final newline
+    # (bash command substitution strips trailing newlines).
+    export SECRET_KEY_BASE="$(cat "$CREDENTIALS_DIRECTORY/SECRET_KEY_BASE")"
+    ${concatMapStringsSep "\n    " (name: ''
+      export ${name}="$(cat "$CREDENTIALS_DIRECTORY/${name}")"
+    '') (lib.attrNames cfg.secretEnvFiles)}
+    ${optionalString cfg.autoMigrate ''
+      ${cfg.package}/bin/blockscout eval 'Explorer.Release.migrate()'
+    ''}
+    exec ${cfg.package}/bin/blockscout start
+  '';
+
 in
 {
   options.services.blockscout-backend = {
@@ -106,11 +106,12 @@ in
       description = ''
         Absolute path to a file containing Phoenix `secret_key_base` —
         64+ bytes of random used to sign user sessions and verify CSRF
-        tokens. Ingested via systemd `LoadCredential=`; the service
-        reads from `$CREDENTIALS_DIRECTORY/secret_key_base`, never
-        from this source path. The file only needs to be readable by
-        systemd (root at unit-start time), not by the `DynamicUser`-
-        allocated UID.
+        tokens. Ingested via systemd `LoadCredential=SECRET_KEY_BASE=<path>`;
+        the ExecStart wrapper reads from
+        `$CREDENTIALS_DIRECTORY/SECRET_KEY_BASE`, never from this
+        source path. The file only needs to be readable by systemd
+        (root at unit-start time), not by the `DynamicUser`-allocated
+        UID.
       '';
     };
 
@@ -259,10 +260,12 @@ in
       type = types.bool;
       default = true;
       description = ''
-        Run `Explorer.Release.migrate()` as an `ExecStartPre` before
-        each service start. Idempotent — running against an already-
-        migrated database is a no-op. Disable only if migrations are
-        orchestrated externally (e.g. a separate admin tool).
+        Run `Explorer.Release.migrate()` in the ExecStart wrapper
+        before starting the server. Idempotent — running against an
+        already-migrated database is a no-op. Disable only if
+        migrations are orchestrated externally (e.g. a separate admin
+        tool) or if the migration step needs different error
+        handling than "fail the whole unit on migration error".
       '';
     };
 
@@ -275,26 +278,19 @@ in
         API_V2_ENABLED = "true";
       };
       description = ''
-        Non-secret environment variables passed to the backend.
+        Non-secret environment variables passed to the backend via
+        systemd's unit-level `environment =` attrset — i.e. as
+        `Environment=KEY=VALUE` entries in the generated unit file.
         Escape hatch for the 50+ Blockscout env vars this module does
-        not expose as first-class options. Values must be strings —
-        Blockscout's runtime-config layer treats all env vars as
-        strings.
+        not expose as first-class options.
 
-        **Values MUST NOT be secrets.** `extraEnv` entries are
-        interpolated into a `pkgs.writeText`-backed file in the Nix
-        store, which is world-readable. For secret-holding env vars
-        (API keys, OAuth client secrets, SMTP credentials, Sentry
-        DSNs, etc.), use `secretEnvFiles` below — those are ingested
-        via systemd `LoadCredential=` and never land in the store.
-
-        **Values MUST NOT contain newlines** — systemd's
-        `EnvironmentFile` parser treats each newline as an entry
-        boundary, so a multi-line value breaks the file. The `#`
-        character and whitespace are fine; quotes and shell
-        metacharacters are preserved literally (values are written
-        via `pkgs.writeText` at Nix-eval time, never via a shell
-        `echo` that could expand them).
+        **Values MUST NOT be secrets.** `extraEnv` entries land in
+        the unit file under `/etc/systemd/system/` (and its Nix-store
+        backing path), which is world-readable. For secret-holding
+        env vars (API keys, OAuth client secrets, SMTP credentials,
+        Sentry DSNs, etc.), use `secretEnvFiles` below — those are
+        ingested via systemd `LoadCredential=` at ExecStart time and
+        never appear in the unit file or the Nix store.
       '';
     };
 
@@ -329,15 +325,18 @@ in
         match `^[A-Z_][A-Z0-9_]*$`); `.path` is an absolute path to
         the file containing its value.
 
-        Each file is ingested via systemd `LoadCredential=` at unit
-        start — the service reads the value from
-        `$CREDENTIALS_DIRECTORY/<NAME>`, never from the source path —
-        and appended to the runtime env file by an `ExecStartPre`
-        step. The value never lands in the Nix store.
+        Each file is ingested via systemd `LoadCredential=<NAME>=<path>`
+        at unit start. The ExecStart shell wrapper reads the value
+        from `$CREDENTIALS_DIRECTORY/<NAME>` and `export`s it into
+        the process environment before `exec`ing the Blockscout
+        release. Values never appear in the Nix store, the unit file,
+        or any `EnvironmentFile`.
 
-        Each file's contents must be a single line (no trailing
-        newline required; a single trailing `\n` is fine). Embedded
-        newlines will break the `EnvironmentFile` parser downstream.
+        Each file's contents must be a single value. Trailing
+        newlines are fine (bash's `$(cat …)` strips them); embedded
+        newlines end up in the env var verbatim, which may or may
+        not be valid depending on how Blockscout parses the specific
+        variable.
       '';
     };
   };
@@ -392,8 +391,39 @@ in
       ];
       wantedBy = [ "multi-user.target" ];
 
+      # Static (non-secret) env — systemd emits these as `Environment=`
+      # directives in the unit file. No EnvironmentFile, no compose
+      # step, no shell parsing of values: systemd passes them directly
+      # to the process's env. Operator-supplied `extraEnv` is merged on
+      # top; a collision on a key Nix defined here is resolved by the
+      # usual attrset `//` semantics (operator wins).
+      environment = {
+        DATABASE_URL = "postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}";
+        ACCOUNT_DATABASE_URL = "postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}";
+        ACCOUNT_REDIS_URL = "unix:///run/redis-${cfg.redisServerName}/redis.sock";
+        ETHEREUM_JSONRPC_VARIANT = "geth";
+        ETHEREUM_JSONRPC_HTTP_URL = cfg.ethereumRpc.httpUrl;
+        ETHEREUM_JSONRPC_WS_URL = cfg.ethereumRpc.wsUrl;
+        ETHEREUM_JSONRPC_TRACE_URL = cfg.ethereumRpc.traceUrl;
+        CHAIN_ID = toString cfg.chain.id;
+        COIN = cfg.chain.coin;
+        COIN_NAME = cfg.chain.coinName;
+        NETWORK = cfg.chain.network;
+        SUBNETWORK = cfg.chain.subnetwork;
+        PORT = toString cfg.http.port;
+        BLOCKSCOUT_HOST = cfg.http.host;
+        BLOCKSCOUT_PROTOCOL = cfg.http.protocol;
+      }
+      // cfg.extraEnv;
+
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/blockscout start";
+        # ExecStart is a small shell wrapper that reads credentials
+        # from $CREDENTIALS_DIRECTORY (populated by LoadCredential=
+        # below), optionally runs the migration, and execs the
+        # Blockscout release. See `startScript` in the top `let` for
+        # the implementation and rationale (EnvironmentFile load
+        # ordering makes it unsuitable for runtime-loaded secrets).
+        ExecStart = startScript;
         Restart = "on-failure";
         RestartSec = "5s";
 
@@ -415,74 +445,15 @@ in
 
         # Secret ingestion. systemd reads each source file as root at
         # unit-start time and exposes the contents via
-        # $CREDENTIALS_DIRECTORY/<name> — the DynamicUser UID never
-        # needs read access to the source paths. `secret_key_base` is
-        # mandatory; everything under `secretEnvFiles` is optional
-        # operator-supplied (API keys, OAuth secrets, etc.).
+        # $CREDENTIALS_DIRECTORY/<NAME> — the DynamicUser UID never
+        # needs read access to the source paths. Credential name
+        # equals env var name (uppercase), so `startScript` can
+        # `cat "$CREDENTIALS_DIRECTORY/$NAME"` and `export $NAME=…`
+        # without any name translation.
         LoadCredential = [
-          "secret_key_base:${cfg.secretKeyBaseFile}"
+          "SECRET_KEY_BASE:${cfg.secretKeyBaseFile}"
         ]
         ++ mapAttrsToList (name: entry: "${name}:${entry.path}") cfg.secretEnvFiles;
-
-        # ExecStartPre: compose $RUNTIME_DIRECTORY/env from the
-        # Nix-generated static env file + all the secrets read from
-        # $CREDENTIALS_DIRECTORY. EnvironmentFile= below reads the
-        # composed file.
-        #
-        # Static values (DATABASE_URL, CHAIN_ID, extraEnv entries,
-        # etc.) are interpolated at Nix-eval time into
-        # `${staticEnvFile}` — no bash `echo` touches them, so no
-        # shell expansion / quote-closure risk. Secrets
-        # (SECRET_KEY_BASE and every `secretEnvFiles` entry) are
-        # appended at runtime from the credential tmpfs via `printf`
-        # + `cat`, which does not interpolate the values.
-        ExecStartPre = [
-          (pkgs.writeShellScript "blockscout-compose-env" ''
-            set -eu
-            umask 077
-
-            # Install the Nix-generated static env file into the
-            # runtime dir at 0600.
-            install -m 0600 ${staticEnvFile} "$RUNTIME_DIRECTORY/env"
-
-            # Append each secret. `printf` + `cat` avoids shell
-            # expansion of the secret contents; credential files are
-            # expected to be a single line (operator responsibility
-            # — embedded newlines would break EnvironmentFile).
-            append_secret() {
-              local key="$1"
-              {
-                printf '%s=' "$key"
-                cat "$CREDENTIALS_DIRECTORY/$key"
-                printf '\n'
-              } >> "$RUNTIME_DIRECTORY/env"
-            }
-
-            append_secret SECRET_KEY_BASE
-            ${concatMapStringsSep "\n" (name: "append_secret ${name}") (lib.attrNames cfg.secretEnvFiles)}
-          '')
-        ]
-        ++ optional cfg.autoMigrate (
-          # No `!` prefix — the migrate step MUST run under the same
-          # DynamicUser + SupplementaryGroups context as the main
-          # unit so `psql` via /run/postgresql/.s.PGSQL.5432 uses the
-          # `blockscout` role's trust auth. Running as root (the `!`
-          # prefix) would bypass the blockscout role entirely.
-          pkgs.writeShellScript "blockscout-migrate" ''
-            set -eu
-            # Source the env file composed above so the migration
-            # script sees DATABASE_URL, SECRET_KEY_BASE, etc.
-            set -a
-            . "$RUNTIME_DIRECTORY/env"
-            set +a
-            exec ${cfg.package}/bin/blockscout eval 'Explorer.Release.migrate()'
-          ''
-        );
-
-        # Use the systemd %t runtime-dir expansion so the path is
-        # correct regardless of whether the service runs with or
-        # without DynamicUser.
-        EnvironmentFile = [ "-%t/blockscout-backend/env" ];
 
         # BEAM JIT needs writable + executable memory pages — opt out
         # of MemoryDenyWriteExecute. Per the nix-modules-hardening
@@ -490,15 +461,26 @@ in
         # keep the default `true`.
         MemoryDenyWriteExecute = false;
 
-        # Defense-in-depth hardening per the nix-modules-hardening
-        # skill matrix.
+        # `PrivateUsers = false` is load-bearing, not a missing
+        # hardening option. The service relies on `SupplementaryGroups`
+        # to reach the PostgreSQL and Redis UNIX sockets; those
+        # sockets are group-owned by `postgres` and `redis-<name>`
+        # respectively at the HOST UID/GID level. `PrivateUsers = true`
+        # would put the service in a user namespace where host GIDs
+        # are remapped (typically to `nobody`), making the kernel's
+        # permission check on the sockets fail with EACCES. Leave
+        # explicitly false with this comment so future hardening
+        # sweeps do not mistakenly re-enable it.
+        PrivateUsers = false;
+
+        # Rest of the defense-in-depth baseline per the
+        # nix-modules-hardening skill matrix.
         CapabilityBoundingSet = [ "" ];
         LockPersonality = true;
         NoNewPrivileges = true;
         PrivateDevices = true;
         PrivateMounts = true;
         PrivateTmp = true;
-        PrivateUsers = true;
         ProcSubset = "pid";
         ProtectClock = true;
         ProtectControlGroups = true;
@@ -527,6 +509,5 @@ in
         UMask = "0077";
       };
     };
-
   };
 }

--- a/modules/blockscout-backend.nix
+++ b/modules/blockscout-backend.nix
@@ -41,10 +41,42 @@ let
     mkIf
     mkBefore
     types
-    concatMapStrings
-    attrNames
+    concatStringsSep
+    mapAttrsToList
     optional
     ;
+
+  # Static env values — Nix-interpolated at module-eval time, written
+  # verbatim into a Nix-store file by `pkgs.writeText`. Because Nix
+  # produces the file content directly (not via `echo` inside a shell
+  # script), values like `db$USER` or `db"quoted"` are stored as
+  # literal characters — no bash expansion, no quote-closure risk.
+  # The file is world-readable in the Nix store; this is fine because
+  # it contains ZERO secrets — only configuration derived from module
+  # options that are already visible in the flake source.
+  staticEnvFile = pkgs.writeText "blockscout-backend.env" (
+    concatStringsSep "\n" (
+      [
+        "DATABASE_URL=postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}"
+        "ACCOUNT_DATABASE_URL=postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}"
+        "ACCOUNT_REDIS_URL=unix:///run/redis-${cfg.redisServerName}/redis.sock"
+        "ETHEREUM_JSONRPC_VARIANT=geth"
+        "ETHEREUM_JSONRPC_HTTP_URL=${cfg.ethereumRpc.httpUrl}"
+        "ETHEREUM_JSONRPC_WS_URL=${cfg.ethereumRpc.wsUrl}"
+        "ETHEREUM_JSONRPC_TRACE_URL=${cfg.ethereumRpc.traceUrl}"
+        "CHAIN_ID=${toString cfg.chain.id}"
+        "COIN=${cfg.chain.coin}"
+        "COIN_NAME=${cfg.chain.coinName}"
+        "NETWORK=${cfg.chain.network}"
+        "SUBNETWORK=${cfg.chain.subnetwork}"
+        "PORT=${toString cfg.http.port}"
+        "BLOCKSCOUT_HOST=${cfg.http.host}"
+        "BLOCKSCOUT_PROTOCOL=${cfg.http.protocol}"
+      ]
+      ++ mapAttrsToList (k: v: "${k}=${v}") cfg.extraEnv
+    )
+    + "\n"
+  );
 in
 {
   options.services.blockscout-backend = {
@@ -149,6 +181,20 @@ in
       };
     };
 
+    # Note on the absence of a `bindAddress` option here:
+    # Blockscout binds its Phoenix endpoint on all interfaces
+    # (`{0, 0, 0, 0}`) and does not read an env var for the listen
+    # address in standard `config/runtime.exs`. Exposure is controlled
+    # by two layers outside this module:
+    #   1. NixOS `networking.firewall` is on by default with `http.port`
+    #      absent from `allowedTCPPorts`, so external TCP reach to :4000
+    #      is dropped.
+    #   2. The `blockscout-nginx` module (upcoming PR) reverse-proxies
+    #      from 127.0.0.1 to this port over loopback, which remains
+    #      reachable regardless of which interface Blockscout binds.
+    # Adding a `bindAddress` option without an upstream Blockscout
+    # patch would be cosmetic — it couldn't actually constrain the
+    # listen behaviour.
     http = {
       port = mkOption {
         type = types.port;
@@ -156,16 +202,10 @@ in
         description = ''
           TCP port the backend's Phoenix endpoint binds. The nginx
           reverse proxy (`blockscout-nginx` module, later PR) is
-          expected to terminate TLS and forward to this port.
-        '';
-      };
-      bindAddress = mkOption {
-        type = types.str;
-        default = "127.0.0.1";
-        description = ''
-          Listen address for the backend Phoenix endpoint. Defaults
-          to loopback — nginx reverse-proxies from the same host.
-          Overriding to a non-loopback value triggers a warning.
+          expected to terminate TLS and forward to this port. The
+          backend listens on all interfaces (Blockscout upstream
+          does not read a listen-IP env var); the NixOS firewall
+          drops external reach to this port by default.
         '';
       };
       host = mkOption {
@@ -218,6 +258,14 @@ in
         not expose as first-class options. Values must be strings —
         Blockscout's runtime-config layer treats all env vars as
         strings.
+
+        **Values MUST NOT contain newlines** — systemd's
+        `EnvironmentFile` parser treats each newline as an entry
+        boundary, so a multi-line value breaks the file. The `#`
+        character and whitespace are fine; quotes and shell
+        metacharacters are preserved literally (values are written
+        via `pkgs.writeText` at Nix-eval time, never via a shell
+        `echo` that could expand them).
       '';
     };
   };
@@ -291,57 +339,52 @@ in
         ];
 
         # ExecStartPre: compose $RUNTIME_DIRECTORY/env from the
-        # credential + config options. EnvironmentFile below reads
-        # that composed file, so the secret never appears in the
-        # unit file or anywhere in the Nix store.
+        # Nix-generated static env file + the secret read from
+        # $CREDENTIALS_DIRECTORY. EnvironmentFile= below reads the
+        # composed file.
+        #
+        # Static values (DATABASE_URL, CHAIN_ID, extraEnv entries,
+        # etc.) are interpolated at Nix-eval time into
+        # `${staticEnvFile}` — no bash `echo` touches them, so no
+        # shell expansion / quote-closure risk. The one secret
+        # (SECRET_KEY_BASE) is appended at runtime from the
+        # credential tmpfs via `printf` + `cat`, which doesn't
+        # interpolate the value.
         ExecStartPre = [
           (pkgs.writeShellScript "blockscout-compose-env" ''
             set -eu
             umask 077
 
-            secret_key_base=$(cat "$CREDENTIALS_DIRECTORY/secret_key_base")
+            # Install the Nix-generated static env file into the
+            # runtime dir at 0600.
+            install -m 0600 ${staticEnvFile} "$RUNTIME_DIRECTORY/env"
 
+            # Append the secret. `printf` + `cat` avoids shell
+            # expansion of the secret's contents; the credential
+            # file is expected to be a single line (operator
+            # responsibility — newlines break EnvironmentFile).
             {
-              echo "DATABASE_URL=postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}"
-              echo "ACCOUNT_DATABASE_URL=postgres://${cfg.databaseUser}@/${cfg.databaseName}?host=${cfg.databaseHost}"
-              echo "SECRET_KEY_BASE=$secret_key_base"
-
-              echo "ACCOUNT_REDIS_URL=unix:///run/redis-${cfg.redisServerName}/redis.sock"
-
-              echo "ETHEREUM_JSONRPC_VARIANT=geth"
-              echo "ETHEREUM_JSONRPC_HTTP_URL=${cfg.ethereumRpc.httpUrl}"
-              echo "ETHEREUM_JSONRPC_WS_URL=${cfg.ethereumRpc.wsUrl}"
-              echo "ETHEREUM_JSONRPC_TRACE_URL=${cfg.ethereumRpc.traceUrl}"
-
-              echo "CHAIN_ID=${toString cfg.chain.id}"
-              echo "COIN=${cfg.chain.coin}"
-              echo "COIN_NAME=${cfg.chain.coinName}"
-              echo "NETWORK=${cfg.chain.network}"
-              echo "SUBNETWORK=${cfg.chain.subnetwork}"
-
-              echo "PORT=${toString cfg.http.port}"
-              echo "BLOCKSCOUT_HOST=${cfg.http.host}"
-              echo "BLOCKSCOUT_PROTOCOL=${cfg.http.protocol}"
-
-              ${concatMapStrings (name: ''
-                echo "${name}=${cfg.extraEnv.${name}}"
-              '') (attrNames cfg.extraEnv)}
-            } > "$RUNTIME_DIRECTORY/env"
+              printf 'SECRET_KEY_BASE='
+              cat "$CREDENTIALS_DIRECTORY/secret_key_base"
+              printf '\n'
+            } >> "$RUNTIME_DIRECTORY/env"
           '')
         ]
         ++ optional cfg.autoMigrate (
-          "!"
-          + toString (
-            pkgs.writeShellScript "blockscout-migrate" ''
-              set -eu
-              # Source the env file composed above so the migration
-              # script sees DATABASE_URL, SECRET_KEY_BASE, etc.
-              set -a
-              . "$RUNTIME_DIRECTORY/env"
-              set +a
-              exec ${cfg.package}/bin/blockscout eval 'Explorer.Release.migrate()'
-            ''
-          )
+          # No `!` prefix — the migrate step MUST run under the same
+          # DynamicUser + SupplementaryGroups context as the main
+          # unit so `psql` via /run/postgresql/.s.PGSQL.5432 uses the
+          # `blockscout` role's trust auth. Running as root (the `!`
+          # prefix) would bypass the blockscout role entirely.
+          pkgs.writeShellScript "blockscout-migrate" ''
+            set -eu
+            # Source the env file composed above so the migration
+            # script sees DATABASE_URL, SECRET_KEY_BASE, etc.
+            set -a
+            . "$RUNTIME_DIRECTORY/env"
+            set +a
+            exec ${cfg.package}/bin/blockscout eval 'Explorer.Release.migrate()'
+          ''
         );
 
         # Use the systemd %t runtime-dir expansion so the path is
@@ -393,17 +436,5 @@ in
       };
     };
 
-    # Loud warning on non-loopback bindAddress. Same pattern as the
-    # autonity module: exposure should be a conscious choice.
-    warnings =
-      let
-        loopbackSafe = [
-          "127.0.0.1"
-          "::1"
-          "localhost"
-        ];
-      in
-      optional (!builtins.elem cfg.http.bindAddress loopbackSafe)
-        "services.blockscout-backend.http.bindAddress is `${cfg.http.bindAddress}` — the backend API will be reachable beyond loopback. Ensure nginx TLS termination and an auth gate are in front of it (the blockscout-nginx module handles this by default).";
   };
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -16,8 +16,8 @@
     ./autonity.nix
     ./blockscout-postgresql.nix
     ./blockscout-redis.nix
+    ./blockscout-backend.nix
     # Service modules land here as they ship:
-    #   ./blockscout-backend.nix
     #   ./blockscout-frontend.nix
     #   ./blockscout-nginx.nix
   ];


### PR DESCRIPTION
## Summary

Fourth service module — the cross-service one where the plumbing established by `autonity` (#4), `blockscout-postgresql` (#7), and `blockscout-redis` (#9) finally comes together. `services.blockscout-backend` runs the Elixir/Phoenix API + indexer as a hardened systemd service that reads chain data from Autonity over loopback JSON-RPC, writes indexed data to PostgreSQL (UNIX socket by default; TCP also supported), and caches via Redis over its UNIX socket.

## Cross-service contract

- **PostgreSQL (default: local UNIX socket; TCP also supported)**: the module detects whether `databaseHost` begins with `/` (`postgresLocal` predicate) and gates four behaviours on it consistently:
  - `after` / `requires` on `postgresql.service` — only when local
  - `SupplementaryGroups = [ "postgres" ]` for socket access — only when local
  - `services.postgresql.authentication = mkBefore "local <db> <user> trust"` — only when local AND `configurePostgresAuth ∈ { null, true }`. Operators can force / suppress with `configurePostgresAuth = true | false`.
  
  Auth rationale when the rule IS installed lives in a long comment in the module: socket filesystem access (gated by group membership) IS the auth boundary on a single-machine deployment; password auth would add a layer with identical blast radius at the cost of password-sync ceremony. For TCP-remote deployments, the operator wires their own auth (PGPASSWORD via `secretEnvFiles`, certificate, etc.) — `databaseHost` description points at this.

- **Redis**: UNIX socket at `/run/redis-${cfg.redisServerName}/redis.sock`; backend joins `redis-${cfg.redisServerName}` group via `SupplementaryGroups`. `redisServerName` is `types.strMatching`-constrained.

- **Autonity**: loopback TCP `127.0.0.1:8545` / `:8546`. `traceUrl` defaults to the HTTP URL; the autonity module ships `gcMode = "archive"` which Blockscout's trace indexer requires.

- **Secrets**: `secretKeyBaseFile` (mandatory) + arbitrary `secretEnvFiles` (optional) — both `types.str` (NOT `types.path`, deliberate to prevent `./file` Nix-store coercion), both validated via `config.assertions` to be absolute and not under `/nix/store/`. Ingested via `LoadCredential=`; exported into the process env by the ExecStart wrapper. Never in the Nix store, unit file, or any `EnvironmentFile`.

- **Static (non-secret) env**: passed via `systemd.services.blockscout-backend.environment = { … }` — direct systemd `Environment=` directives. No file parsing ambiguity, no shell expansion, no load-ordering risk.

## Listen-address / exposure model

Blockscout binds its Phoenix endpoint on all interfaces (`{0, 0, 0, 0}`); upstream does not read a listen-IP env var in `config/runtime.exs`. External exposure is constrained outside this module:

1. NixOS `networking.firewall` is on by default; `http.port` is not in `allowedTCPPorts`, so external TCP reach is dropped.
2. The upcoming `blockscout-nginx` module reverse-proxies from `127.0.0.1` over loopback.

There is deliberately **no `http.bindAddress` option** — it would be cosmetic without an upstream Blockscout patch.

## Option surface

- `enable`, `package` (`mkPackageOption pkgs "blockscout"`)
- `secretKeyBaseFile` — `types.str`, required. Asserted absolute + not under `/nix/store/`.
- `secretEnvFiles` — `attrsOf submodule { options.path = str; }`. Keys validated against `^[A-Z_][A-Z0-9_]*$`; each `.path` validated absolute + not under `/nix/store/`.
- `databaseHost` — `types.str`. Either an absolute socket-dir path (`/run/postgresql`, default) or a TCP hostname (`pg.prod.internal`, `localhost`). Documented: which behaviours activate / deactivate per shape.
- `databaseName` / `databaseUser` — `types.strMatching "^[a-zA-Z_][a-zA-Z0-9_]*$"` (SQL identifier; injection-safe for pg_hba interpolation).
- `redisServerName` — `types.strMatching "^[a-z0-9][a-z0-9_-]*$"`.
- `configurePostgresAuth` — `types.nullOr types.bool`, default `null`. `null` → auto-detect from `postgresLocal`; `true` / `false` → explicit override.
- `ethereumRpc.{httpUrl, wsUrl, traceUrl}` — loopback Autonity defaults.
- `chain.{id, coin, coinName, network, subnetwork}` — MainNet defaults.
- `http.{port, host, protocol}` — `4000` / `localhost` / `http` defaults.
- `autoMigrate` (default `true`) — runs `Explorer.Release.migrate()` in the ExecStart wrapper before starting the server.
- `extraEnv` — non-secret string-only attrset, merged into `systemd.services.*.environment`. Documented constraint: no secrets (lands in unit file).

## Secrets — ingestion + lifecycle

Two-tier model, both ingested via `LoadCredential=` + `$CREDENTIALS_DIRECTORY/<NAME>`:

```nix
LoadCredential = [
  "SECRET_KEY_BASE:${cfg.secretKeyBaseFile}"
] ++ mapAttrsToList (name: entry: "${name}:${entry.path}") cfg.secretEnvFiles;
```

ExecStart is a small `pkgs.writeShellScript` wrapper that exports each credential and execs the release:

```bash
set -eu
export SECRET_KEY_BASE="$(cat "$CREDENTIALS_DIRECTORY/SECRET_KEY_BASE")"
export ETHERSCAN_API_KEY="$(cat "$CREDENTIALS_DIRECTORY/ETHERSCAN_API_KEY")"
…
${cfg.package}/bin/blockscout eval 'Explorer.Release.migrate()'   # if autoMigrate
exec ${cfg.package}/bin/blockscout start
```

Bash command substitution captures credential bytes verbatim; bash variable assignment doesn't re-expand `$` / backticks / quotes in the value, so secrets containing shell metacharacters are preserved literally. No shell parsing of any EnvironmentFile syntax happens anywhere in this module — by design (R3 architectural decision: see `Review history` below).

Operator example:

```nix
services.blockscout-backend.secretEnvFiles = {
  ACCOUNT_AUTH0_CLIENT_SECRET.path = "/run/secrets/blockscout/auth0_client_secret";
  ETHERSCAN_API_KEY.path           = "/run/secrets/blockscout/etherscan_key";
};
```

Each key must match `^[A-Z_][A-Z0-9_]*$` (validated via `config.assertions`); each `.path` must be absolute and not under `/nix/store/` (also validated).

## Safety / hardening

- `DynamicUser`, `StateDirectory` + `RuntimeDirectory` both `0700`.
- `MemoryDenyWriteExecute = false` (BEAM JIT opt-out).
- `RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ]` (no `AF_NETLINK` — backend doesn't enumerate interfaces).
- `CapabilityBoundingSet = [ "" ]`, `NoNewPrivileges`, `LockPersonality`, full filesystem / kernel-protection set.
- `SystemCallFilter` with standard deny set + `@memlock`.
- **`PrivateUsers = false`** — load-bearing. `SupplementaryGroups = [ "postgres" "redis-…" ]` resolves at the host UID/GID level; `PrivateUsers = true` would remap host GIDs to `nobody` inside a user namespace and break socket access. Inline comment in the module documents this so future hardening sweeps don't re-enable.
- **No shell injection into env values**: static values flow through systemd's `Environment=` (no shell parsing); secrets go through bash variable assignment via `$(cat …)` (no re-expansion).
- **No pg_hba injection from operator-supplied identifiers**: `databaseName` / `databaseUser` constrained to SQL-identifier regex.
- **No pg_hba injection when remote**: `services.postgresql.authentication` only fires when `databaseHost` is a UNIX socket directory (or operator forces via `configurePostgresAuth = true`). Remote-PG deployments leave the host's `services.postgresql` untouched.
- **No accidental Nix-store secret leak**: `secretKeyBaseFile` and `secretEnvFiles.*.path` use `types.str` (rejects Nix-path literals) plus `config.assertions` rejecting any value under `/nix/store/`.

## Flake input + lockfile

- New `blockscout` input → `github:klazomenai/blockscout`. `follows` on both `nixpkgs` AND `flake-utils` so the lockfile stays deduplicated.
- Overlay entry: `pkgs.blockscout = blockscout.packages.<system>.default`.

## Test plan

- [x] `nix flake check --print-build-logs` passes locally on `x86_64-linux`
- [ ] `.github/workflows/flake-check.yml` runs green on this PR
- [x] `nix eval .#nixosModules.default` evaluates cleanly with all four service modules imported
- [x] `databaseHost = "/run/postgresql"` → `services.postgresql.authentication` gets the local trust rule, `requires`/`after`/`SupplementaryGroups.postgres` all active
- [x] `databaseHost = "localhost"` → `services.postgresql.authentication` evaluates to `""` (verified empirically with `nix eval`), no `postgresql.service` dependency, no `postgres` SupplementaryGroup
- [x] `MemoryDenyWriteExecute = false` with inline BEAM-JIT comment
- [x] `PrivateUsers = false` with inline cross-service-socket-access comment
- [x] `flake.lock` has `flake-utils` + `systems` only once each (no `_2` duplicates)
- [ ] `secretKeyBaseFile = "/nix/store/abc-leaked"` rejected at option-set time by `config.assertions`
- [ ] `secretEnvFiles.<NAME>.path` similarly asserted
- [ ] `SupplementaryGroups = [ "redis-blockscout" "postgres" ]` present in the unit when local; only `[ "redis-blockscout" ]` when TCP

## Review history

- **R1** (3): removed dead `http.bindAddress` option + warning; removed `!` prefix on migrate ExecStartPre; rewrote env-file generation to avoid bash expansion of operator values.
- **R2** (3): added `secretEnvFiles` option (closes the `extraEnv`-via-Nix-store leak path); synced PR body to post-R1 surface; tightened `databaseName` / `databaseUser` types with SQL-identifier regex (closes pg_hba injection).
- **R3** (3): credential name mismatch (`secret_key_base` vs `SECRET_KEY_BASE`) was a startup-failure bug — fixed by unifying naming. `EnvironmentFile=` had a category mistake hiding a deeper load-ordering bug (file is read at unit activation, BEFORE `ExecStartPre` populates it — main `ExecStart` never saw the env vars via the intended mechanism). **Architectural pivot**: dropped `staticEnvFile` (`pkgs.writeText`), the compose-env `ExecStartPre`, the migrate `ExecStartPre`, and `EnvironmentFile=` entirely. Static env now goes through `systemd.services.*.environment` (direct systemd `Environment=`); secrets go through an `ExecStart` shell wrapper that exports them from `$CREDENTIALS_DIRECTORY`. `PrivateUsers = true` set explicitly to `false` with a long comment — it broke `SupplementaryGroups` socket access (host GID remapping inside the user namespace).
- **R4** (4): `secretKeyBaseFile` and `secretEnvFiles.*.path` types narrowed from `types.path` to `types.str` (Nix-path literals would auto-copy into the world-readable Nix store); per-value `config.assertions` reject `/nix/store/` paths and require absolute. Added `configurePostgresAuth` option (`nullOr bool`, auto-detect via `postgresLocal`, explicit override) so the module stops always modifying `services.postgresql.authentication` even when pointed at TCP. Added descriptions to `databaseName` / `databaseUser`.
- **R5** (1): completed R4's local-PG gating — `requires`, `after`, and `SupplementaryGroups.postgres` were still firing unconditionally. Factored the `postgresLocal = lib.hasPrefix "/" cfg.databaseHost` predicate and applied it consistently across all four sites.
- **R6** (1): `databaseHost` description rewritten to document the post-R5 dual-shape behaviour (socket dir vs TCP hostname) instead of the original socket-only assumption.
- **R7** (1): pushed back on a Copilot claim that `lib.mkIf cond stringValue` produces an attrset type-mismatch when condition is false. Verified empirically with `nix eval` that the module-system marker semantics work correctly — `services.postgresql.authentication` evaluates to `""` (a valid string) when the gate is false. No code change. Pattern is used widely in nixpkgs.
- **R8** (1, this update): synced this PR body to match R3-R7 — the body had been describing the pre-R3 design (`staticEnvFile` + `append_secret`) which no longer exists.

Refs #11
