### PR TITLE
feat(nix): blockscout-frontend module with declarative envs.js overlay ⛵

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,6 +46,29 @@
         "type": "github"
       }
     },
+    "blockscout-frontend": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776844306,
+        "narHash": "sha256-KVQvoOwt6A37yqA9AtWf75+lxIZ+UBSQP7Za8EmGDz8=",
+        "owner": "klazomenai",
+        "repo": "blockscout-frontend",
+        "rev": "aed8251025b29d8319e2e03e9a3cb32f3da9ee8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "klazomenai",
+        "repo": "blockscout-frontend",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -84,6 +107,7 @@
       "inputs": {
         "autonity": "autonity",
         "blockscout": "blockscout",
+        "blockscout-frontend": "blockscout-frontend",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,18 @@
     blockscout.url = "github:klazomenai/blockscout";
     blockscout.inputs.nixpkgs.follows = "nixpkgs";
     blockscout.inputs.flake-utils.follows = "flake-utils";
+
+    # Blockscout frontend (Next.js standalone) — produced by the
+    # `klazomenai/blockscout-frontend` fork's flake. The NixOS
+    # blockscout-frontend module defaults
+    # `services.blockscout-frontend.package` to `pkgs.blockscout-frontend`,
+    # wired via the nixpkgs.overlays entry below. Runtime configuration
+    # (NEXT_PUBLIC_*) is regenerated into envs.js by the module at unit
+    # start and overlaid onto the package's shipped placeholder via
+    # `BindReadOnlyPaths`.
+    blockscout-frontend.url = "github:klazomenai/blockscout-frontend";
+    blockscout-frontend.inputs.nixpkgs.follows = "nixpkgs";
+    blockscout-frontend.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs =
@@ -32,6 +44,7 @@
       flake-utils,
       autonity,
       blockscout,
+      blockscout-frontend,
     }:
     let
       # Scope locked to x86_64-linux for the glue repo and all service
@@ -53,6 +66,7 @@
             autonity = autonity.packages.${final.stdenv.hostPlatform.system}.default;
             autonity-portable = autonity.packages.${final.stdenv.hostPlatform.system}.autonity-portable;
             blockscout = blockscout.packages.${final.stdenv.hostPlatform.system}.default;
+            blockscout-frontend = blockscout-frontend.packages.${final.stdenv.hostPlatform.system}.default;
           })
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -29,9 +29,9 @@
     # blockscout-frontend module defaults
     # `services.blockscout-frontend.package` to `pkgs.blockscout-frontend`,
     # wired via the nixpkgs.overlays entry below. Runtime configuration
-    # (NEXT_PUBLIC_*) is regenerated into envs.js by the module at unit
-    # start and overlaid onto the package's shipped placeholder via
-    # `BindReadOnlyPaths`.
+    # (NEXT_PUBLIC_*) is generated into envs.js via `pkgs.writeText`
+    # during Nix evaluation/build time and overlaid onto the package's
+    # shipped placeholder via `BindReadOnlyPaths`.
     blockscout-frontend.url = "github:klazomenai/blockscout-frontend";
     blockscout-frontend.inputs.nixpkgs.follows = "nixpkgs";
     blockscout-frontend.inputs.flake-utils.follows = "flake-utils";

--- a/modules/blockscout-frontend.nix
+++ b/modules/blockscout-frontend.nix
@@ -1,0 +1,274 @@
+# NixOS service module for the Blockscout frontend (Next.js standalone
+# server, packaged by the `klazomenai/blockscout-frontend` flake).
+#
+# Cross-service contract:
+#   - Backend: queried over loopback TCP at the URL composed from
+#     publicEnv.NEXT_PUBLIC_API_{HOST,PROTOCOL,PORT}. The frontend's SSR
+#     pipeline hits this URL during page rendering; the browser hits it
+#     directly for client-side navigation. Defaults match the
+#     blockscout-backend module's loopback :4000 binding.
+#   - Listen address: `127.0.0.1:3000` by default. External exposure is
+#     terminated by the `blockscout-nginx` module (upcoming PR), which
+#     reverse-proxies from 0.0.0.0:443 to this loopback port. Like the
+#     backend, the NixOS firewall drops external reach to the frontend
+#     port by default (it's not in `allowedTCPPorts`).
+#
+# Runtime configuration (NEXT_PUBLIC_*):
+#   The Blockscout frontend reads runtime config in two places:
+#   1. Server-side (SSR, API routes): `process.env.NEXT_PUBLIC_*`.
+#      Provided here via `systemd.services.*.environment` (direct
+#      `Environment=` entries).
+#   2. Client-side (browser): `window.__envs`, populated by a
+#      synchronously-loaded `/assets/envs.js` script in the page head.
+#      The package ships a placeholder envs.js generated at flake build
+#      time from a hardcoded placeholder publicEnv attrset; this module
+#      generates a real envs.js at NixOS evaluation time from the
+#      operator's `publicEnv` and uses systemd `BindReadOnlyPaths` to
+#      overlay it onto the package's path inside the unit's mount
+#      namespace. Same source-of-truth attrset feeds both layers, so
+#      server and client cannot disagree.
+#
+# The `klazomenai/blockscout-frontend` flake is wired into pkgs via a
+# nixpkgs.overlays entry on the glue-repo's nixosModules.default (see
+# ../flake.nix), so `pkgs.blockscout-frontend` resolves to the Next.js
+# standalone derivation.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.blockscout-frontend;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkPackageOption
+    mkIf
+    types
+    mapAttrsToList
+    ;
+
+  # NEXT_PUBLIC_* — same regex Next.js itself uses to decide which env
+  # vars are inlined into the client bundle. Everything else stays
+  # server-only. Enforced at config.assertions time so a typo'd or
+  # deliberately non-public key (e.g. an API token) cannot end up in
+  # the client-readable envs.js by accident.
+  publicEnvKeyRegex = "^NEXT_PUBLIC_[A-Z0-9_]+$";
+
+  # envs.js generated at Nix evaluation time. The frontend's
+  # `pages/_document.tsx` loads this synchronously in the page head;
+  # the browser exposes the values as `window.__envs`. JSON serialisation
+  # via `builtins.toJSON` handles quoting so values containing quotes,
+  # backslashes, or non-ASCII characters round-trip safely.
+  envsJs = pkgs.writeText "blockscout-frontend-envs.js" ''
+    window.__envs = ${builtins.toJSON cfg.publicEnv};
+  '';
+in
+{
+  options.services.blockscout-frontend = {
+    enable = mkEnableOption "the Blockscout Next.js frontend";
+
+    package = mkPackageOption pkgs "blockscout-frontend" { };
+
+    host = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+      description = ''
+        Listen address for the Next.js standalone server. Defaults to
+        loopback; external exposure is terminated by the
+        `blockscout-nginx` module. Setting `0.0.0.0` here without an
+        explicit firewall opening or reverse proxy in front would still
+        be blocked by the NixOS firewall (the port is not in
+        `allowedTCPPorts` by default).
+      '';
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 3000;
+      description = ''
+        TCP port the Next.js standalone server binds. The
+        `blockscout-nginx` module proxies from 443 to this loopback
+        port.
+      '';
+    };
+
+    publicEnv = mkOption {
+      # Keys constrained to the NEXT_PUBLIC_* shape — same convention
+      # Next.js itself uses to mark variables as safe for client
+      # exposure. config.assertions below additionally cross-checks
+      # each key, so the error message names the offending key.
+      type = types.attrsOf types.str;
+      default = {
+        NEXT_PUBLIC_API_HOST = "localhost";
+        NEXT_PUBLIC_API_PROTOCOL = "http";
+        NEXT_PUBLIC_API_PORT = "4000";
+        NEXT_PUBLIC_NETWORK_NAME = "Autonity";
+        NEXT_PUBLIC_NETWORK_SHORT_NAME = "ATN";
+        NEXT_PUBLIC_NETWORK_ID = "65000000";
+        NEXT_PUBLIC_NETWORK_RPC_URL = "http://localhost:8545";
+        NEXT_PUBLIC_NETWORK_CURRENCY_NAME = "Auton";
+        NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL = "ATN";
+        NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS = "18";
+        NEXT_PUBLIC_APP_HOST = "localhost";
+        NEXT_PUBLIC_APP_PROTOCOL = "http";
+        NEXT_PUBLIC_APP_PORT = "3000";
+      };
+      description = ''
+        Public, browser-readable runtime configuration. Every key MUST
+        begin with `NEXT_PUBLIC_` and contain only uppercase letters,
+        digits, and underscores. Values land in two places:
+
+        - `process.env.${"\${name}"}` on the server (SSR, API routes),
+          via `systemd.services.*.environment` directives.
+        - `window.__envs.${"\${name}"}` in the browser, via a generated
+          `envs.js` script bind-mounted onto the package's
+          `public/assets/envs.js`.
+
+        Both paths read from this same attrset so server and client
+        configuration cannot drift.
+
+        Defaults match Autonity MainNet for smoke testing. Production
+        deployments override `NEXT_PUBLIC_API_HOST`,
+        `NEXT_PUBLIC_APP_HOST`, and `NEXT_PUBLIC_*_PROTOCOL` to match
+        the public domain served through the nginx reverse proxy.
+      '';
+    };
+
+    extraEnv = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      example = {
+        NODE_OPTIONS = "--max-old-space-size=2048";
+        NEXT_TELEMETRY_DISABLED = "1";
+      };
+      description = ''
+        Non-`NEXT_PUBLIC_` environment variables for the Next.js
+        server process — typically Node.js runtime tuning
+        (`NODE_OPTIONS`, `NEXT_TELEMETRY_DISABLED`) or non-public
+        config picked up by Blockscout's `instrumentation.node.ts`.
+        Merged on top of `publicEnv` and the module's static
+        `Environment=` entries; operator-supplied keys win on
+        collision.
+
+        **NEXT_PUBLIC_* keys belong in `publicEnv`, not here.** Only
+        `publicEnv` is reflected into the browser-readable envs.js.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Validate every publicEnv key matches the NEXT_PUBLIC_* shape.
+    # Catches typos (NEXT_PUBLI_*) and deliberate non-public values
+    # (API tokens, secrets) that would otherwise leak into the
+    # client-readable envs.js.
+    assertions = mapAttrsToList (name: _: {
+      assertion = builtins.match publicEnvKeyRegex name != null;
+      message = "services.blockscout-frontend.publicEnv key `${name}` must match `${publicEnvKeyRegex}`. Non-public env vars belong in `extraEnv` (server-side only).";
+    }) cfg.publicEnv;
+
+    systemd.services.blockscout-frontend = {
+      description = "Blockscout Next.js frontend";
+      after = [
+        "network-online.target"
+        # Soft dependency: SSR queries the backend, but Next.js
+        # handles transient upstream failures gracefully (renders the
+        # error boundary). Hard `requires` would couple frontend
+        # availability to backend startup ordering for no benefit.
+        "blockscout-backend.service"
+      ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      # Single source of truth: publicEnv goes into both the server's
+      # process.env (via these Environment= directives) and the
+      # browser's window.__envs (via envsJs + BindReadOnlyPaths in
+      # serviceConfig below). HOST and PORT control the bind address
+      # of the Next.js standalone server (`server.js` reads
+      # process.env.HOSTNAME and process.env.PORT). NEXT_TELEMETRY is
+      # always disabled — telemetry collection has no place in a
+      # production explorer.
+      environment = {
+        HOSTNAME = cfg.host;
+        PORT = toString cfg.port;
+        NEXT_TELEMETRY_DISABLED = "1";
+      }
+      // cfg.publicEnv
+      // cfg.extraEnv;
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/blockscout-frontend";
+        Restart = "on-failure";
+        RestartSec = "5s";
+
+        DynamicUser = true;
+        StateDirectory = "blockscout-frontend";
+        StateDirectoryMode = "0700";
+        RuntimeDirectory = "blockscout-frontend";
+        RuntimeDirectoryMode = "0700";
+
+        # Overlay the operator-configured envs.js onto the package's
+        # placeholder. The frontend's `pages/_document.tsx` loads
+        # `/assets/envs.js` synchronously; the package's flake build
+        # ships a placeholder generated from a hardcoded publicEnv
+        # attrset, intended to be replaced at deploy time.
+        # `BindReadOnlyPaths` mounts the Nix-store-resident envsJs
+        # over the placeholder inside the unit's private mount
+        # namespace — the host's filesystem is unaffected, the
+        # operation is reversible (unit stop reverts it), and no
+        # writable scratch directory or file copy is needed.
+        BindReadOnlyPaths = [
+          "${envsJs}:${cfg.package}/public/assets/envs.js"
+        ];
+
+        # V8 JIT needs writable + executable memory pages — opt out
+        # of MemoryDenyWriteExecute. Per the nix-modules-hardening
+        # skill's JIT exception list (Node.js / V8 alongside BEAM,
+        # OpenJDK, LuaJIT, PyPy, .NET).
+        MemoryDenyWriteExecute = false;
+
+        # Rest of the defense-in-depth baseline per the
+        # nix-modules-hardening skill matrix. The frontend has no
+        # cross-service UNIX socket dependencies (it talks to the
+        # backend over loopback TCP), so PrivateUsers can be left at
+        # the systemd default — unlike blockscout-backend, where
+        # PrivateUsers = false is load-bearing for SupplementaryGroups
+        # socket access.
+        CapabilityBoundingSet = [ "" ];
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RemoveIPC = true;
+        # No AF_NETLINK — the frontend does not enumerate interfaces
+        # or read routing information.
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@cpu-emulation @debug @keyring @memlock @mount @obsolete @privileged @resources @setuid"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/modules/blockscout-frontend.nix
+++ b/modules/blockscout-frontend.nix
@@ -157,19 +157,38 @@ in
 
         **NEXT_PUBLIC_* keys belong in `publicEnv`, not here.** Only
         `publicEnv` is reflected into the browser-readable envs.js.
+
+        **Do not put secrets here.** Values from `extraEnv` are passed
+        via `systemd.services.*.environment`, so they end up in the
+        generated systemd unit and its Nix-store backing path, which
+        are world-readable.
       '';
     };
   };
 
   config = mkIf cfg.enable {
-    # Validate every publicEnv key matches the NEXT_PUBLIC_* shape.
-    # Catches typos (NEXT_PUBLI_*) and deliberate non-public values
-    # (API tokens, secrets) that would otherwise leak into the
-    # client-readable envs.js.
-    assertions = mapAttrsToList (name: _: {
-      assertion = builtins.match publicEnvKeyRegex name != null;
-      message = "services.blockscout-frontend.publicEnv key `${name}` must match `${publicEnvKeyRegex}`. Non-public env vars belong in `extraEnv` (server-side only).";
-    }) cfg.publicEnv;
+    # Validate the public/private env split:
+    #   - publicEnv keys MUST match the NEXT_PUBLIC_* shape (catches
+    #     typos like `NEXT_PUBLI_FOO` and rejects deliberate non-public
+    #     values such as API tokens that would otherwise leak into the
+    #     client-readable envs.js).
+    #   - extraEnv keys MUST NOT match the NEXT_PUBLIC_* shape — these
+    #     are server-side only. publicEnv is the single source of truth
+    #     for `NEXT_PUBLIC_*` values, which feed both the server's
+    #     process.env (via Environment= directives) and the browser's
+    #     window.__envs (via envsJs + BindReadOnlyPaths). If extraEnv
+    #     could carry NEXT_PUBLIC_* keys, they'd land in process.env
+    #     for the SSR layer but NOT in envs.js, so server-rendered
+    #     pages and client-side hydration would disagree.
+    assertions =
+      mapAttrsToList (name: _: {
+        assertion = builtins.match publicEnvKeyRegex name != null;
+        message = "services.blockscout-frontend.publicEnv key `${name}` must match `${publicEnvKeyRegex}`. Non-public env vars belong in `extraEnv` (server-side only).";
+      }) cfg.publicEnv
+      ++ mapAttrsToList (name: _: {
+        assertion = builtins.match publicEnvKeyRegex name == null;
+        message = "services.blockscout-frontend.extraEnv key `${name}` must not match `${publicEnvKeyRegex}`. Public env vars belong in `publicEnv` so process.env.NEXT_PUBLIC_* and window.__envs stay in sync.";
+      }) cfg.extraEnv;
 
     systemd.services.blockscout-frontend = {
       description = "Blockscout Next.js frontend";
@@ -190,8 +209,9 @@ in
       # serviceConfig below). HOSTNAME and PORT control the bind address
       # of the Next.js standalone server (`server.js` reads
       # process.env.HOSTNAME and process.env.PORT). NEXT_TELEMETRY is
-      # always disabled — telemetry collection has no place in a
-      # production explorer.
+      # disabled by default; an operator can override via `extraEnv` if
+      # they explicitly want it on, but the default is off because
+      # telemetry collection has no place in a production explorer.
       environment = {
         HOSTNAME = cfg.host;
         PORT = toString cfg.port;

--- a/modules/blockscout-frontend.nix
+++ b/modules/blockscout-frontend.nix
@@ -50,11 +50,13 @@ let
     mapAttrsToList
     ;
 
-  # NEXT_PUBLIC_* — same regex Next.js itself uses to decide which env
-  # vars are inlined into the client bundle. Everything else stays
-  # server-only. Enforced at config.assertions time so a typo'd or
-  # deliberately non-public key (e.g. an API token) cannot end up in
-  # the client-readable envs.js by accident.
+  # NEXT_PUBLIC_* — Next.js itself exposes env vars to the client based
+  # on the `NEXT_PUBLIC_` prefix. This module intentionally applies the
+  # stricter `^NEXT_PUBLIC_[A-Z0-9_]+$` validation when accepting keys
+  # for `publicEnv`, so everything else stays server-only. Enforced at
+  # config.assertions time so a typo'd or deliberately non-public key
+  # (e.g. an API token) cannot end up in the client-readable envs.js by
+  # accident.
   publicEnvKeyRegex = "^NEXT_PUBLIC_[A-Z0-9_]+$";
 
   # envs.js generated at Nix evaluation time. The frontend's
@@ -185,7 +187,7 @@ in
       # Single source of truth: publicEnv goes into both the server's
       # process.env (via these Environment= directives) and the
       # browser's window.__envs (via envsJs + BindReadOnlyPaths in
-      # serviceConfig below). HOST and PORT control the bind address
+      # serviceConfig below). HOSTNAME and PORT control the bind address
       # of the Next.js standalone server (`server.js` reads
       # process.env.HOSTNAME and process.env.PORT). NEXT_TELEMETRY is
       # always disabled — telemetry collection has no place in a

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -17,8 +17,8 @@
     ./blockscout-postgresql.nix
     ./blockscout-redis.nix
     ./blockscout-backend.nix
+    ./blockscout-frontend.nix
     # Service modules land here as they ship:
-    #   ./blockscout-frontend.nix
     #   ./blockscout-nginx.nix
   ];
 }


### PR DESCRIPTION
## Summary

Fifth service module. Runs the Blockscout Next.js frontend (packaged by `klazomenai/blockscout-frontend`) as a hardened systemd service, with the per-deployment public configuration declarative end-to-end: a single `publicEnv` attrset feeds both the server's `process.env` (via `Environment=`) and the browser's `window.__envs` (via a Nix-store-resident `envs.js` bind-mounted onto the package's placeholder).

## Cross-service contract

- **Backend**: queried over loopback TCP at the URL composed from `publicEnv.NEXT_PUBLIC_API_{HOST,PROTOCOL,PORT}`. SSR pipeline + browser navigation both hit it. Defaults match the `blockscout-backend` module's loopback `:4000` binding.
- **Listen address**: `127.0.0.1:3000` by default. External exposure is the `blockscout-nginx` module's job (next PR); the NixOS firewall drops external reach to `:3000` by default (it's not in `allowedTCPPorts`).
- **No cross-service UNIX socket dependencies** — no `SupplementaryGroups`, no `postgres`/`redis-*` group joins, so `PrivateUsers` stays at the systemd default (unlike `blockscout-backend`, where `PrivateUsers = false` is load-bearing).

## Runtime config — single source of truth

Blockscout's frontend reads runtime config in two places:

1. **Server-side** (SSR + API routes): `process.env.NEXT_PUBLIC_*`.
2. **Client-side** (browser): `window.__envs`, populated by a synchronously-loaded `/assets/envs.js` script in the page head.

The package ships a placeholder `envs.js` generated at flake build time from a hardcoded placeholder `publicEnv` attrset (intended to be replaced at deploy time — upstream's Dockerfile uses a `make_envs_script.sh` shell helper). This module does the replacement at NixOS evaluation time:

- `pkgs.writeText` produces an `envs.js` derivation from the operator's `cfg.publicEnv` via `builtins.toJSON` (handles quoting, backslashes, non-ASCII).
- `BindReadOnlyPaths = "${envsJs}:${cfg.package}/public/assets/envs.js"` overlays the file inside the unit's private mount namespace. Host filesystem is unaffected; the operation reverts on unit stop.
- The same `publicEnv` attrset feeds `systemd.services.*.environment` so server-side `process.env` matches the browser-side `window.__envs` exactly.

No runtime `ExecStartPre` step, no scratch directory, no shell helper — the configuration is already known at NixOS evaluation time.

## Option surface

- `enable`, `package` (`mkPackageOption pkgs "blockscout-frontend"`)
- `host` — `types.str`, default `"127.0.0.1"`. Bind address; external exposure is the nginx module's job.
- `port` — `types.port`, default `3000`.
- `publicEnv` — `attrsOf str`. Defaults match Autonity MainNet (`NEXT_PUBLIC_NETWORK_ID = "65000000"`, `NEXT_PUBLIC_NETWORK_RPC_URL = "http://localhost:8545"`, etc., mirroring the upstream flake's placeholder publicEnv). Each key validated against `^NEXT_PUBLIC_[A-Z0-9_]+$` via `config.assertions` — a typo'd key or a deliberately non-public value (API token, OAuth secret) is rejected at option-set time rather than silently leaking into the client-readable envs.js.
- `extraEnv` — `attrsOf str`. Non-`NEXT_PUBLIC_` server-side env (`NODE_OPTIONS`, etc.). Documented constraint: `NEXT_PUBLIC_*` keys belong in `publicEnv`, not here.

## Hardening

- `DynamicUser`, `StateDirectory` + `RuntimeDirectory` mode `0700`.
- **`MemoryDenyWriteExecute = false`** — V8 JIT opt-out (Node.js runtime), per the `nix-modules-hardening` skill JIT exception list (alongside BEAM in the backend module). Inline comment cites the skill.
- `RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ]` — no `AF_NETLINK` (frontend doesn't enumerate interfaces).
- `CapabilityBoundingSet = [ "" ]`, `NoNewPrivileges`, `LockPersonality`, full filesystem / kernel-protection set.
- `SystemCallFilter` with the standard deny set.
- No `extraEnv`-via-Nix-store secret leak path: `extraEnv` is documented as non-secret-only; secret-holding values aren't part of this module's contract (frontend has no secret-holding env vars in the standard Blockscout deployment — auth happens at the backend layer).

## Flake input + lockfile

- New `blockscout-frontend` input → `github:klazomenai/blockscout-frontend`. `follows` on both `nixpkgs` AND `flake-utils` so the lockfile stays deduplicated alongside the existing `autonity` and `blockscout` inputs.
- Overlay entry: `pkgs.blockscout-frontend = blockscout-frontend.packages.<system>.default`.

## Test plan

- [x] `nix flake check --print-build-logs` passes locally on `x86_64-linux` (`checks.fmt` covers the new file).
- [ ] `.github/workflows/flake-check.yml` runs green on this PR.
- [x] `nix eval .#nixosModules.default` evaluates cleanly with all five service modules imported.
- [x] Module evaluation against a stub NixOS system: `BindReadOnlyPaths` renders with the correct envs.js source path and `cfg.package`-derived destination.
- [x] `environment` includes `HOSTNAME = "127.0.0.1"`, `PORT = "3000"`, `NEXT_TELEMETRY_DISABLED = "1"`, plus every `publicEnv` key.
- [x] `MemoryDenyWriteExecute = false` with inline V8-JIT comment.
- [x] `RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" ]` (no `AF_NETLINK`).
- [x] `services.blockscout-frontend.publicEnv.SECRET_API_TOKEN = "leak-me"` rejected at option-set time by `config.assertions`:
  > services.blockscout-frontend.publicEnv key `SECRET_API_TOKEN` must match `^NEXT_PUBLIC_[A-Z0-9_]+$`. Non-public env vars belong in `extraEnv` (server-side only).
- [x] `flake.lock` has `flake-utils` + `systems` only once each (no `_2` duplicates) after adding the new input.
- [ ] Full-stack `nixosTest` integration — lands with the dedicated `nixosTest` PR.

Refs #13
