### PR TITLE
feat(nix): blockscout-nginx reverse-proxy module with ACME 🔐

### DIFF
--- a/modules/blockscout-nginx.nix
+++ b/modules/blockscout-nginx.nix
@@ -56,21 +56,33 @@ in
     enable = mkEnableOption "the Blockscout reverse proxy + ACME TLS termination";
 
     serverName = mkOption {
-      # Server name regex: hostname-shape characters only. Used verbatim
-      # as both the `services.nginx.virtualHosts.<name>` attribute key
-      # AND interpolated into the nginx `server_name` directive — so
-      # rejecting whitespace, quotes, semicolons, and other unsafe
-      # nginx-config metacharacters at option-set time prevents config
-      # injection regardless of where the value flows.
-      type = types.strMatching "^[a-zA-Z0-9.-]+$";
+      # Server name regex: RFC 1035 DNS labels — each label 1-63 chars,
+      # starts and ends with alphanumeric, may contain hyphens internally;
+      # one or more labels separated by dots; total length not enforced
+      # at the regex level (DNS allows 253 chars, far longer than any
+      # realistic explorer hostname). This is stricter than a generic
+      # "hostname-shape characters" regex because the loose form admits
+      # leading dots, trailing dots, empty labels (`a..b`), and lone
+      # `-` — all of which evaluate cleanly here but produce a broken
+      # nginx / ACME config later. Fail at option-set time instead.
+      #
+      # Used verbatim as both the `services.nginx.virtualHosts.<name>`
+      # attribute key AND interpolated into the nginx `server_name`
+      # directive — the regex is also the single point of truth for
+      # safe nginx-config interpolation (rejects whitespace / quotes /
+      # semicolons by construction).
+      type = types.strMatching "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$";
       example = "explorer.example.com";
       description = ''
-        Public hostname this reverse proxy serves. Must be a DNS-shape
-        hostname (letters, digits, dots, hyphens). The operator is
-        responsible for ensuring an A / AAAA record points at this
-        host's public IP before enabling ACME — Let's Encrypt's HTTP-01
-        challenge fails closed if the hostname does not resolve to the
-        validating server.
+        Public hostname this reverse proxy serves. Must be a valid
+        DNS hostname per RFC 1035: one or more labels separated by
+        dots; each label 1-63 characters of alphanumerics with
+        optional internal hyphens; no leading or trailing dots, no
+        empty labels, no leading or trailing hyphens within a label.
+        The operator is responsible for ensuring an A / AAAA record
+        points at this host's public IP before enabling ACME — Let's
+        Encrypt's HTTP-01 challenge fails closed if the hostname does
+        not resolve to the validating server.
       '';
     };
 
@@ -90,16 +102,33 @@ in
       };
 
       email = mkOption {
-        type = types.str;
+        # Pragmatic email-shape regex: `<local>@<domain-with-dot>`.
+        # Not RFC 5322 (that grammar is famously unparsable by regex)
+        # and not a deliverability check — just enough shape validation
+        # to reject obvious typos at option-set time rather than at
+        # ACME registration time, where the failure surfaces as a
+        # `journalctl -u acme-…` line that operators don't always see.
+        # Empty string is permitted at the type level so operators
+        # evaluating with `acme.enable = false` aren't forced to
+        # provide a placeholder; the assertion in `config` requires
+        # non-empty when ACME is on.
+        type = types.strMatching "^$|^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
         default = "";
         example = "ops@example.com";
         description = ''
           Account email for the Let's Encrypt registration. Required
           when `acme.enable = true` (enforced via `config.assertions`).
           LE uses this address for expiry warnings and TOS update
-          notifications; an unattended deployment that never reads
-          this mailbox is fine, but the registration itself requires
-          a valid email format.
+          notifications.
+
+          Validated at option-set time against an
+          `^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$` shape —
+          a pragmatic "looks like an email" check rather than a full
+          RFC 5322 grammar. Empty string is accepted by the type to
+          let operators evaluate with `acme.enable = false` without
+          providing a placeholder; the non-empty requirement is
+          enforced separately via `config.assertions` only when ACME
+          is enabled.
         '';
       };
 
@@ -123,23 +152,39 @@ in
     };
 
     frontend.upstream = mkOption {
-      type = types.str;
+      # `host:port` shape — host part hostname-or-IPv4 characters
+      # (alphanumerics, dots, hyphens), port part digits-only. Used in
+      # `proxyPass = "http://${cfg.frontend.upstream}"`, so a typo
+      # (embedded whitespace, semicolon, double colon) would surface
+      # only at `nginx -t` during unit ExecStartPre. Catching it at
+      # option-set time produces a clearer error pointing at the
+      # offending option.
+      type = types.strMatching "^[a-zA-Z0-9.-]+:[0-9]+$";
       default = "127.0.0.1:3000";
       description = ''
-        `host:port` of the Blockscout frontend service. Defaults match
+        `host:port` of the Blockscout frontend service (no scheme —
+        the module proxies via `http://`). Defaults match
         `services.blockscout-frontend.{host,port}`'s defaults. All
         traffic not matching a backend prefix is proxied here.
+
+        Validated at option-set time against
+        `^[a-zA-Z0-9.-]+:[0-9]+$` to catch typos before they reach
+        the nginx config-test stage.
       '';
     };
 
     backend.upstream = mkOption {
-      type = types.str;
+      type = types.strMatching "^[a-zA-Z0-9.-]+:[0-9]+$";
       default = "127.0.0.1:4000";
       description = ''
-        `host:port` of the Blockscout backend service. Defaults match
+        `host:port` of the Blockscout backend service (no scheme —
+        the module proxies via `http://`). Defaults match
         `services.blockscout-backend.http.port` on loopback. The
         `/api`, `/api/v2`, `/socket`, `/health`, and `/metrics` path
         prefixes are proxied here.
+
+        Same `^[a-zA-Z0-9.-]+:[0-9]+$` validation as
+        `frontend.upstream`.
       '';
     };
 
@@ -182,15 +227,25 @@ in
   };
 
   config = mkIf cfg.enable {
-    # ACME requires a contact email when enabled. The empty default on
-    # `acme.email` keeps the option non-required at the type level so
-    # operators evaluating with `acme.enable = false` don't have to
-    # provide a placeholder; the assertion fires only when ACME is
-    # actually enabled.
+    # Two assertions:
+    #   1. ACME requires a contact email when enabled. The empty
+    #      default on `acme.email` keeps the option non-required at
+    #      the type level so operators evaluating with
+    #      `acme.enable = false` don't have to provide a placeholder.
+    #   2. `services.nginx.enable` is set to `mkDefault true` below,
+    #      but another module (or operator config) explicitly setting
+    #      `services.nginx.enable = false` wins by priority. Without
+    #      this assertion the module would still open firewall ports
+    #      and configure ACME state for a non-existent nginx unit.
+    #      Fail fast with a clear message instead.
     assertions = [
       {
         assertion = !cfg.acme.enable || cfg.acme.email != "";
         message = "services.blockscout-nginx.acme.email must be set (non-empty) when services.blockscout-nginx.acme.enable is true. Let's Encrypt registration requires a contact email for expiry warnings and TOS updates.";
+      }
+      {
+        assertion = config.services.nginx.enable;
+        message = "services.blockscout-nginx.enable = true requires services.nginx.enable = true (this module sets it via lib.mkDefault, but another module or your configuration is explicitly disabling it).";
       }
     ];
 
@@ -202,23 +257,41 @@ in
       443
     ];
 
-    # ACME terms acceptance + default email. `mkIf cfg.acme.enable`
-    # ensures we don't touch `security.acme` at all when the operator
-    # is wiring their own cert — same pattern blockscout-backend uses
-    # for `services.postgresql.authentication`.
-    security.acme = mkIf cfg.acme.enable (
-      {
-        acceptTerms = true;
-        defaults.email = cfg.acme.email;
+    # ACME terms acceptance is a global one-time setting (legal accept
+    # for using ACME at all on this host) — it has to live at the
+    # top level, but it's idempotent across multiple ACME consumers.
+    # The email and (when staging) server URL are scoped to OUR cert
+    # via `security.acme.certs.${cfg.serverName}` rather than
+    # `security.acme.defaults.*`, so other ACME-consuming modules on
+    # the same host (e.g. a separate vhost the operator manages) keep
+    # their own per-cert email and staging choices. This module owns
+    # one vhost; it doesn't speak for the host.
+    #
+    # The double gate (`cfg.acme.enable && config.services.nginx.enable`)
+    # keeps us from defining a partial `security.acme.certs.<name>`
+    # entry when nginx is explicitly disabled — that would surface as
+    # nixpkgs' "exactly one of dnsProvider/webroot/listenHTTP/s3Bucket
+    # is required" assertion (because the nginx-vhost integration
+    # auto-populates `webroot`, but only if nginx is enabled). Our
+    # `cfg.enable -> services.nginx.enable` assertion above already
+    # explains the operator-facing problem; this gate suppresses the
+    # downstream nixpkgs assertion that would otherwise clutter the
+    # error output.
+    security.acme = mkIf (cfg.acme.enable && config.services.nginx.enable) {
+      acceptTerms = true;
+      certs.${cfg.serverName} = {
+        email = cfg.acme.email;
       }
       // optionalAttrs cfg.acme.useStaging {
-        # LE staging directory. Issued certs are signed by a non-trusted
-        # root, so browsers warn until the operator flips back to
-        # production. Useful for first-run validation without burning
-        # the production rate limit on configuration errors.
-        defaults.server = "https://acme-staging-v02.api.letsencrypt.org/directory";
-      }
-    );
+        # LE staging directory. Issued certs are signed by a non-
+        # trusted root, so browsers warn until the operator flips
+        # back to production. Useful for first-run validation without
+        # burning the production rate limit on configuration errors.
+        # Scoped to this cert only — staging on the explorer vhost
+        # does not bleed into other ACME certs the host issues.
+        server = "https://acme-staging-v02.api.letsencrypt.org/directory";
+      };
+    };
 
     # Compose the reverse proxy vhost. Zero overrides on
     # `systemd.services.nginx` — nixpkgs ships the nginx unit with

--- a/modules/blockscout-nginx.nix
+++ b/modules/blockscout-nginx.nix
@@ -1,0 +1,284 @@
+# NixOS service module for the Blockscout reverse proxy. Composes
+# nixpkgs `services.nginx` to terminate TLS in front of the
+# `blockscout-backend` (loopback :4000) and `blockscout-frontend`
+# (loopback :3000) services, with Let's Encrypt-issued certificates
+# managed by `security.acme`.
+#
+# This is the only externally-binding service module in the data plane
+# besides Autonity P2P (port 30303): the rest of the stack listens on
+# loopback only. The defense-in-depth posture is layered:
+#   - the data-plane services are firewalled (their ports are NOT in
+#     `networking.firewall.allowedTCPPorts`);
+#   - this module opens 80 + 443 and reverse-proxies the public traffic
+#     onto loopback, where the upstream services see only loopback
+#     connections.
+#
+# Cross-service contract:
+#   - Frontend: `127.0.0.1:3000` by default (matches
+#     `services.blockscout-frontend`'s default bind). All traffic that
+#     does not match a backend prefix routes here. WebSocket upgrade
+#     headers are preserved (Next.js dev mode + future feature parity).
+#   - Backend: `127.0.0.1:4000` by default (matches
+#     `services.blockscout-backend`'s `http.port`). Path prefixes:
+#       /api, /api/v2 — REST and JSON-RPC endpoints
+#       /socket       — Phoenix WebSocket channel for live updates
+#       /health, /metrics — Blockscout introspection
+#   - TLS: Let's Encrypt via HTTP-01 by default. `useStaging` toggles
+#     to LE's staging directory for first-run validation (production
+#     LE has a strict rate limit; running staging first avoids burning
+#     it on dry-run errors).
+#
+# This module does NOT override `systemd.services.nginx`. nixpkgs ships
+# the nginx unit with `CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ]`
+# (needed to bind 80/443 as a non-root service), `ProtectSystem = strict`,
+# and the rest of the hardening matrix; the wrapper composes routes via
+# `services.nginx.virtualHosts` and leaves the unit's serviceConfig
+# alone — same thin-wrapper pattern as `blockscout-postgresql` and
+# `blockscout-redis`.
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  cfg = config.services.blockscout-nginx;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    types
+    optionalAttrs
+    ;
+in
+{
+  options.services.blockscout-nginx = {
+    enable = mkEnableOption "the Blockscout reverse proxy + ACME TLS termination";
+
+    serverName = mkOption {
+      # Server name regex: hostname-shape characters only. Used verbatim
+      # as both the `services.nginx.virtualHosts.<name>` attribute key
+      # AND interpolated into the nginx `server_name` directive — so
+      # rejecting whitespace, quotes, semicolons, and other unsafe
+      # nginx-config metacharacters at option-set time prevents config
+      # injection regardless of where the value flows.
+      type = types.strMatching "^[a-zA-Z0-9.-]+$";
+      example = "explorer.example.com";
+      description = ''
+        Public hostname this reverse proxy serves. Must be a DNS-shape
+        hostname (letters, digits, dots, hyphens). The operator is
+        responsible for ensuring an A / AAAA record points at this
+        host's public IP before enabling ACME — Let's Encrypt's HTTP-01
+        challenge fails closed if the hostname does not resolve to the
+        validating server.
+      '';
+    };
+
+    acme = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Whether to obtain a TLS certificate via Let's Encrypt
+          (`security.acme`). When false, the module composes the
+          virtual host without `enableACME` and the operator is
+          expected to wire their own certificate via
+          `services.nginx.virtualHosts.${"\${serverName}"}.sslCertificate`
+          / `.sslCertificateKey` (or via a separately-managed ACME
+          host).
+        '';
+      };
+
+      email = mkOption {
+        type = types.str;
+        default = "";
+        example = "ops@example.com";
+        description = ''
+          Account email for the Let's Encrypt registration. Required
+          when `acme.enable = true` (enforced via `config.assertions`).
+          LE uses this address for expiry warnings and TOS update
+          notifications; an unattended deployment that never reads
+          this mailbox is fine, but the registration itself requires
+          a valid email format.
+        '';
+      };
+
+      useStaging = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Issue certificates against Let's Encrypt's staging directory
+          rather than production. Use `true` for first-run smoke
+          testing of a new deployment — production LE has tight rate
+          limits (50 certificates per registered domain per week, 5
+          duplicate certificates per week) which are easy to exhaust
+          on configuration errors. Flip back to `false` once HTTP-01
+          validation reliably succeeds.
+
+          Staging certificates are signed by a non-trusted root, so
+          browsers will display a warning until the operator switches
+          back to production.
+        '';
+      };
+    };
+
+    frontend.upstream = mkOption {
+      type = types.str;
+      default = "127.0.0.1:3000";
+      description = ''
+        `host:port` of the Blockscout frontend service. Defaults match
+        `services.blockscout-frontend.{host,port}`'s defaults. All
+        traffic not matching a backend prefix is proxied here.
+      '';
+    };
+
+    backend.upstream = mkOption {
+      type = types.str;
+      default = "127.0.0.1:4000";
+      description = ''
+        `host:port` of the Blockscout backend service. Defaults match
+        `services.blockscout-backend.http.port` on loopback. The
+        `/api`, `/api/v2`, `/socket`, `/health`, and `/metrics` path
+        prefixes are proxied here.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to open TCP 80 and 443 in `networking.firewall`. Most
+        deployments leave this `true`. Set `false` for deployments
+        sitting behind a separate load balancer that does TLS
+        termination and proxies plaintext loopback traffic to nginx;
+        in that case the operator opens whatever ports the LB
+        forwards on directly.
+      '';
+    };
+
+    extraVirtualHostConfig = mkOption {
+      type = types.lines;
+      default = "";
+      example = ''
+        # Strict transport security — 1 year, include subdomains, preload
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        # Content security policy
+        add_header Content-Security-Policy "default-src 'self'; …" always;
+      '';
+      description = ''
+        Operator-supplied nginx configuration injected verbatim into
+        the virtual host's `extraConfig` block. Use for security
+        headers (HSTS, CSP, X-Frame-Options), rate limiting, geo
+        blocks, or any other vhost-level directive this module does
+        not expose first-class.
+
+        Inserted as-is into the generated config; the operator is
+        responsible for valid nginx syntax. nginx config errors
+        surface at `nginx -t` (run automatically as part of the unit's
+        `ExecStartPre`), so a typo here will fail the service
+        activation rather than silently load a broken config.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # ACME requires a contact email when enabled. The empty default on
+    # `acme.email` keeps the option non-required at the type level so
+    # operators evaluating with `acme.enable = false` don't have to
+    # provide a placeholder; the assertion fires only when ACME is
+    # actually enabled.
+    assertions = [
+      {
+        assertion = !cfg.acme.enable || cfg.acme.email != "";
+        message = "services.blockscout-nginx.acme.email must be set (non-empty) when services.blockscout-nginx.acme.enable is true. Let's Encrypt registration requires a contact email for expiry warnings and TOS updates.";
+      }
+    ];
+
+    # Open the public web ports. Gated on `openFirewall` so deployments
+    # behind a dedicated load balancer (where the LB is the only thing
+    # touching the public IP) can leave the host's firewall closed.
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [
+      80
+      443
+    ];
+
+    # ACME terms acceptance + default email. `mkIf cfg.acme.enable`
+    # ensures we don't touch `security.acme` at all when the operator
+    # is wiring their own cert — same pattern blockscout-backend uses
+    # for `services.postgresql.authentication`.
+    security.acme = mkIf cfg.acme.enable (
+      {
+        acceptTerms = true;
+        defaults.email = cfg.acme.email;
+      }
+      // optionalAttrs cfg.acme.useStaging {
+        # LE staging directory. Issued certs are signed by a non-trusted
+        # root, so browsers warn until the operator flips back to
+        # production. Useful for first-run validation without burning
+        # the production rate limit on configuration errors.
+        defaults.server = "https://acme-staging-v02.api.letsencrypt.org/directory";
+      }
+    );
+
+    # Compose the reverse proxy vhost. Zero overrides on
+    # `systemd.services.nginx` — nixpkgs ships the nginx unit with
+    # CAP_NET_BIND_SERVICE + the rest of its hardening matrix already
+    # applied; this wrapper only configures routes.
+    services.nginx = {
+      enable = lib.mkDefault true;
+      recommendedProxySettings = lib.mkDefault true;
+      recommendedTlsSettings = lib.mkDefault true;
+      recommendedGzipSettings = lib.mkDefault true;
+      recommendedOptimisation = lib.mkDefault true;
+
+      virtualHosts.${cfg.serverName} = {
+        forceSSL = true;
+        enableACME = cfg.acme.enable;
+
+        # Default route — everything that doesn't match a backend
+        # prefix lands at the frontend. proxyWebsockets sets the
+        # Upgrade + Connection headers; recommendedProxySettings
+        # already covers Host / X-Real-IP / X-Forwarded-For/Proto.
+        locations."/" = {
+          proxyPass = "http://${cfg.frontend.upstream}";
+          proxyWebsockets = true;
+        };
+
+        # Backend REST + JSON-RPC.
+        locations."/api" = {
+          proxyPass = "http://${cfg.backend.upstream}";
+        };
+        locations."/api/v2" = {
+          proxyPass = "http://${cfg.backend.upstream}";
+        };
+
+        # Phoenix WebSocket channel for live block / tx updates.
+        # proxyWebsockets sets Upgrade + Connection headers; the
+        # extended timeouts cover quiet periods between server-side
+        # heartbeats. Default nginx proxy_read_timeout is 60s, which
+        # would close the channel during low-block-rate stretches.
+        locations."/socket" = {
+          proxyPass = "http://${cfg.backend.upstream}";
+          proxyWebsockets = true;
+          extraConfig = ''
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+          '';
+        };
+
+        # Blockscout introspection endpoints. Operators wanting to
+        # restrict /metrics to internal networks should add an
+        # `allow … deny all;` block via `extraVirtualHostConfig` or
+        # override the location directly.
+        locations."/health" = {
+          proxyPass = "http://${cfg.backend.upstream}";
+        };
+        locations."/metrics" = {
+          proxyPass = "http://${cfg.backend.upstream}";
+        };
+
+        extraConfig = cfg.extraVirtualHostConfig;
+      };
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,14 +1,13 @@
 # Aggregate NixOS module for the autonity-blockscout-nixos stack.
 #
 # Composes every service module shipped by this repo via the imports
-# list below. New service modules are added here as they land; the
-# commented placeholders show the remaining planned additions for the
-# Blockscout side of the stack. The bootstrap PR (#2) intentionally
-# shipped this file empty so the glue-repo scaffolding (flake.nix,
-# devenv.nix, CI, release-please, issue/PR templates, LICENSE,
-# CONTRIBUTING.md) could be reviewed independently of any service-
-# module semantics; this PR introduces the first real service module
-# (`autonity.nix`).
+# list below. The bootstrap PR (#2) shipped this file empty so the
+# glue-repo scaffolding (flake.nix, devenv.nix, CI, release-please,
+# issue/PR templates, LICENSE, CONTRIBUTING.md) could be reviewed
+# independently of any service-module semantics. The data-plane chain
+# now flows top-to-bottom: chain (autonity) → indexer/API
+# (blockscout-{postgresql,redis,backend}) → UI (blockscout-frontend) →
+# TLS termination (blockscout-nginx).
 { ... }:
 
 {
@@ -18,7 +17,6 @@
     ./blockscout-redis.nix
     ./blockscout-backend.nix
     ./blockscout-frontend.nix
-    # Service modules land here as they ship:
-    #   ./blockscout-nginx.nix
+    ./blockscout-nginx.nix
   ];
 }


### PR DESCRIPTION
## Summary

Sixth and final service module of epic #3. Terminates TLS in front of the Blockscout backend (loopback :4000) and frontend (loopback :3000) on a single externally-reachable hostname, with Let's Encrypt-issued certificates managed by `security.acme`.

This is the only externally-binding service module in the data plane besides Autonity P2P (`30303`); the rest of the stack listens on loopback only. Defense in depth is layered:

- data-plane services keep their ports out of `allowedTCPPorts`
- this module opens 80 + 443 and reverse-proxies the public traffic onto loopback, where the upstream services see only loopback connections.

## Cross-service contract

- **Listen**: external `0.0.0.0:80` and `0.0.0.0:443`. Port `80` redirects to `443` via `forceSSL`. The module opens both in `networking.firewall.allowedTCPPorts` by default; operators can opt out via `openFirewall = false` for deployments fronting nginx with a dedicated load balancer.
- **Upstream — frontend**: loopback TCP to `127.0.0.1:3000` (default; configurable). All traffic that does not match a backend prefix lands here. WebSocket upgrade headers preserved.
- **Upstream — backend**: loopback TCP to `127.0.0.1:4000` (default; configurable). Path prefixes:
  - `/api` and `/api/v2` — REST and JSON-RPC endpoints
  - `/socket` — Phoenix WebSocket channel (`proxy_{read,send}_timeout = 86400s` because the default nginx `60s` would close it during quiet stretches between heartbeats)
  - `/health` and `/metrics` — Blockscout introspection
- **TLS**: Let's Encrypt via HTTP-01 by default. `acme.useStaging = true` routes to the LE staging directory **for our cert only** — see "ACME scoping" below.
- **Zero overrides on `systemd.services.nginx`** — nixpkgs ships nginx with `CapabilityBoundingSet = [ "CAP_NET_BIND_SERVICE" ]` (needed to bind 80/443 as a non-root service), `ProtectSystem = strict`, and the rest of the hardening matrix; the wrapper composes routes via `services.nginx.virtualHosts` and leaves the unit alone. Same thin-wrapper pattern as `blockscout-postgresql` (#7) and `blockscout-redis` (#9).

## ACME scoping

Per-cert, not host-wide. The module sets:

- `security.acme.acceptTerms = true` (top-level — this is a one-time legal accept for using ACME at all on this host; nixpkgs' API only exposes it as a single boolean, idempotent across all ACME consumers).
- `security.acme.certs.${cfg.serverName}.email = cfg.acme.email` (per-cert).
- `security.acme.certs.${cfg.serverName}.server = "https://acme-staging-v02.api.letsencrypt.org/directory"` when `cfg.acme.useStaging = true` (per-cert).

`security.acme.defaults.{email,server}` are NOT touched. Other ACME-consuming modules on the same host (e.g. a separately-managed vhost the operator owns) keep their own per-cert email and staging choices — this module owns one vhost; it doesn't speak for the host.

The `security.acme` block is gated on `cfg.acme.enable && config.services.nginx.enable` so a half-defined cert (just `email` set, `webroot` not yet auto-populated by the nginx-vhost integration because nginx itself is disabled) doesn't surface nixpkgs' downstream "exactly one of dnsProvider/webroot/listenHTTP/s3Bucket is required" assertion. Operators who explicitly disable `services.nginx.enable` see only this module's targeted `cfg.enable -> services.nginx.enable` assertion.

## Option surface

- `enable`
- `serverName` — `types.strMatching "^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"`. RFC 1035 DNS labels: each label 1–63 chars, alphanumeric ends, hyphens allowed only internally; one or more dot-separated labels. Rejects pathological cases (`.foo.com`, `foo..com`, `foo-`, `-foo`, lone `-`) at option-set time. Used verbatim as both the `services.nginx.virtualHosts.<name>` attribute key AND interpolated into the nginx `server_name` directive, so the regex is the single point of truth for safe interpolation.
- `acme.enable` — `types.bool`, default `true`. When false, `enableACME` is skipped on the vhost; operator wires their own cert.
- `acme.email` — `types.strMatching "^$|^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"`, default `""`. Pragmatic email-shape regex; not RFC 5322 (that grammar is famously unparsable). Empty string permitted at the type level so operators evaluating with `acme.enable = false` aren't forced to provide a placeholder; the non-empty requirement is enforced via `config.assertions` only when ACME is enabled.
- `acme.useStaging` — `types.bool`, default `false`. Toggles `security.acme.certs.${cfg.serverName}.server` to the LE staging directory (per-cert; does not affect other ACME consumers on the host).
- `frontend.upstream` — `types.strMatching "^[a-zA-Z0-9.-]+:[0-9]+$"`, default `"127.0.0.1:3000"`. Host part hostname-or-IPv4 chars; port part digits-only. Catches typos (embedded whitespace, semicolons, double colons) at option-set time rather than at `nginx -t` during ExecStartPre.
- `backend.upstream` — same regex, default `"127.0.0.1:4000"`.
- `openFirewall` — `types.bool`, default `true`.
- `extraVirtualHostConfig` — `types.lines`, default `""`. Operator escape hatch for HSTS / CSP / rate limiting / etc. Documented constraint: arbitrary nginx config injected verbatim — operators are responsible for valid syntax (a typo here will surface at `nginx -t` during ExecStartPre and fail activation rather than load a broken config).

## Safety / hardening

- **No `systemd.services.nginx` overrides** — nixpkgs hardening preserved verbatim.
- **No nginx-config injection from operator-supplied identifiers**: `serverName` constrained to RFC 1035 DNS-label shape via `types.strMatching` at option-set time.
- **No accidental ACME registration without an email**: assertion gates the LE registration on a non-empty `acme.email` (LE rejects registrations without a contact email anyway, but failing fast at NixOS evaluation gives a clearer error than waiting for the ACME failure log).
- **No half-configured cert on disabled nginx**: `security.acme` block gated on `services.nginx.enable`; targeted `cfg.enable -> services.nginx.enable` assertion explains the operator-facing problem with no downstream nixpkgs clutter.
- **Staging path is per-cert**: enabling `acme.useStaging` does not poison other ACME consumers on the same host with non-trusted certs.
- **`useStaging` first-run path**: documented as the recommended starting point for new deployments to avoid burning the production LE rate limit on dry-run errors.
- **`recommendedProxySettings = mkDefault true`**: covers `Host`, `X-Real-IP`, `X-Forwarded-{For,Proto,Host}` headers — Blockscout's Phoenix endpoint reads these to emit correct absolute URLs (otherwise it would emit URLs based on the loopback Host header, breaking generated links).
- **`recommendedTlsSettings = mkDefault true`**: TLS 1.2+ only, modern cipher suites, OCSP stapling. Operators wanting TLS 1.3-only or different cipher policy can override individual `services.nginx.*` settings or use `extraVirtualHostConfig`.

## Test plan

- [x] `nix flake check --print-build-logs` passes locally on `x86_64-linux` (`checks.fmt` covers the new file).
- [ ] `.github/workflows/flake-check.yml` runs green on this PR.
- [x] `nix eval .#nixosModules.default` evaluates cleanly with all six service modules imported.
- [x] Stub NixOS eval with `acme.enable = true`, `acme.useStaging = true`, `acme.email = "ops@example.com"`:
  - `security.acme.acceptTerms = true`
  - `security.acme.defaults.email` stays at nixpkgs default (`null`); `security.acme.defaults.server` stays at LE production
  - `security.acme.certs."explorer.example.com".email = "ops@example.com"`, `.server = "https://acme-staging-v02.api.letsencrypt.org/directory"`, `.webroot = "/var/lib/acme/acme-challenge"` (auto-populated by the nginx-vhost integration), `.group = "nginx"`
  - `networking.firewall.allowedTCPPorts` includes 80 and 443
  - `services.nginx.virtualHosts."explorer.example.com"`: `forceSSL = true`, `enableACME = true`
  - `/` proxyPass to frontend with `proxyWebsockets = true`
  - `/api`, `/api/v2`, `/socket`, `/health`, `/metrics` proxyPass to backend
  - `/socket` has `proxyWebsockets = true`
  - `recommendedProxySettings = true`
- [x] `acme.enable = true` with empty `acme.email` rejected at option-set time:
  > services.blockscout-nginx.acme.email must be set (non-empty) when services.blockscout-nginx.acme.enable is true. Let's Encrypt registration requires a contact email for expiry warnings and TOS updates.
- [x] `acme.email = "not-an-email"` rejected by `types.strMatching` (no `@`).
- [x] `acme.enable = false` → `security.acme.acceptTerms` defaults to `false` (untouched by us); vhost has `enableACME = false`.
- [x] `serverName = ".explorer.example.com"` (leading dot — pathological case the looser pre-R1 regex accepted) rejected by `types.strMatching`.
- [x] `backend.upstream = "127.0.0.1::4000"` (typo: double colon) rejected by `types.strMatching`.
- [x] `services.nginx.enable = false` with `services.blockscout-nginx.enable = true` rejected at assertion time (single targeted message; `security.acme` gating suppresses downstream nixpkgs assertions).
- [ ] Live HTTP-01 validation against a real public IP — M3 OVH deployment phase.
- [ ] Full-stack `nixosTest` integration — lands with the dedicated `nixosTest` PR (uses self-signed certs in the VM, no live ACME).

Closes the M2 service-module phase of epic #3 — 6 of 6 service modules now shipped. Remaining M2 work: hardening spike + full-stack `nixosTest` VM integration.

## Review history

- **R1** (5): tightened five validations / scopings caught at NixOS evaluation time rather than nginx config-test or ACME registration time. (1) `serverName` regex from generic hostname-shape to RFC 1035 DNS labels; (2) `acme.email` from `types.str` + non-empty assertion to a pragmatic email-shape regex; (3) `security.acme.{email,server}` from `defaults.*` (host-wide) to `certs.<serverName>.*` (per-cert); (4) added `cfg.enable -> services.nginx.enable` assertion (kept `mkDefault true` to respect explicit operator override); (5) tightened both `{frontend,backend}.upstream` from unconstrained `types.str` to `^[a-zA-Z0-9.-]+:[0-9]+$`. Side-effect: gated `security.acme` on `services.nginx.enable` so the new assertion's negative path doesn't surface a downstream nixpkgs cert-challenge-type assertion.
- **R2** (1, this update): synced the PR description to match the post-R1 per-cert ACME scoping (the original body said `useStaging` toggles `security.acme.defaults.server`, accurate at PR-open time but stale after R1).

Refs #15
