### PR TITLE
feat(nix): services.autonity.staticNodes option ⛵

### DIFF
--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -243,6 +243,39 @@ in
       '';
     };
 
+    staticNodes = mkOption {
+      type = types.nullOr (types.listOf types.str);
+      default = null;
+      example = [
+        "enode://abc123@1.2.3.4:30303"
+        "enode://def456@5.6.7.8:30303"
+      ];
+      description = ''
+        Pinned peers that the node always tries to maintain a
+        connection to, in addition to peers acquired through
+        discovery. Useful when bootnodes are unavailable or when an
+        operator wants a guaranteed link between two specific nodes.
+
+        When non-null, the list is JSON-serialised at Nix evaluation
+        time and written to `static-nodes.json` in the service's
+        `StateDirectory` (`''${cfg.dataDir}/static-nodes.json`) at
+        unit start — this is the Geth-family file convention, used
+        by Autonity verbatim. Autonity does not expose a direct
+        `--staticnodes` CLI flag; the file is the only supported
+        input. The file is staged in the Nix store via
+        `pkgs.writeText` and copied into the StateDirectory by an
+        `ExecStartPre=` step (mode 0600, owned by the unit's dynamic
+        user), so the staged-in-store version is world-readable but
+        the in-state-dir version is not. The enode URIs are NOT
+        secrets — they're public node-identity hints — so the
+        store-resident staged copy carries no secrecy concern.
+
+        When `null` (default), no `ExecStartPre=` fires and no JSON
+        file is written; Autonity reads no static-peers list and
+        relies entirely on `bootnodes` + discovery.
+      '';
+    };
+
     metrics.enable = mkEnableOption "the Autonity Prometheus metrics endpoint";
 
     extraArgs = mkOption {
@@ -274,6 +307,22 @@ in
 
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/autonity ${args} ${lib.escapeShellArgs cfg.extraArgs}";
+
+        # Stage `static-nodes.json` into StateDirectory at unit start
+        # when `staticNodes` is non-null. The file is the Geth-family
+        # convention for pinned peers — Autonity does not accept a
+        # `--staticnodes` CLI flag, so the on-disk file is the only
+        # supported input. `install -m 0600` overwrites any existing
+        # file, ensuring rebuilds with a changed list always take
+        # effect on the next start (not just on first boot). When
+        # `staticNodes` is null, the list `lib.optional` below
+        # evaluates to `[]` and no ExecStartPre fires.
+        ExecStartPre = lib.optional (cfg.staticNodes != null) (
+          "${pkgs.coreutils}/bin/install -m 0600 -T "
+          + "${pkgs.writeText "static-nodes.json" (builtins.toJSON cfg.staticNodes)} "
+          + "\${STATE_DIRECTORY}/static-nodes.json"
+        );
+
         Restart = "on-failure";
         RestartSec = "5s";
 

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -247,8 +247,8 @@ in
       type = types.nullOr (types.listOf types.str);
       default = null;
       example = [
-        "enode://abc123@1.2.3.4:30303"
-        "enode://def456@5.6.7.8:30303"
+        "enode://0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef@1.2.3.4:30303"
+        "enode://fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210@5.6.7.8:30303"
       ];
       description = ''
         Pinned peers that the node always tries to maintain a
@@ -259,16 +259,20 @@ in
         When non-null, the list is JSON-serialised at Nix evaluation
         time and written to `static-nodes.json` in the service's
         `StateDirectory` (`''${cfg.dataDir}/static-nodes.json`) at
-        unit start — this is the Geth-family file convention, used
-        by Autonity verbatim. Autonity does not expose a direct
-        `--staticnodes` CLI flag; the file is the only supported
-        input. The file is staged in the Nix store via
-        `pkgs.writeText` and copied into the StateDirectory by an
-        `ExecStartPre=` step (mode 0600, owned by the unit's dynamic
-        user), so the staged-in-store version is world-readable but
-        the in-state-dir version is not. The enode URIs are NOT
-        secrets — they're public node-identity hints — so the
-        store-resident staged copy carries no secrecy concern.
+        unit start — this is the legacy Geth-family file convention,
+        which Autonity still reads verbatim. Autonity does not
+        expose a direct `--staticnodes` CLI flag; this module uses
+        the `static-nodes.json` path rather than TOML-based config,
+        which upstream Geth-family nodes also support (Autonity logs
+        a deprecation warning recommending the TOML form, but reads
+        the JSON file regardless). The file is staged in the Nix
+        store via `pkgs.writeText` and copied into the StateDirectory
+        by an `ExecStartPre=` step (mode 0600, owned by the unit's
+        dynamic user), so the staged-in-store version is
+        world-readable but the in-state-dir version is not. The
+        enode URIs are NOT secrets — they're public node-identity
+        hints — so the store-resident staged copy carries no secrecy
+        concern.
 
         When `null` (default), no `ExecStartPre=` fires and no JSON
         file is written; Autonity reads no static-peers list and

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -313,14 +313,17 @@ in
         ExecStart = "${cfg.package}/bin/autonity ${args} ${lib.escapeShellArgs cfg.extraArgs}";
 
         # Stage `static-nodes.json` into StateDirectory at unit start
-        # when `staticNodes` is non-null. The file is the Geth-family
-        # convention for pinned peers — Autonity does not accept a
-        # `--staticnodes` CLI flag, so the on-disk file is the only
-        # supported input. `install -m 0600` overwrites any existing
-        # file, ensuring rebuilds with a changed list always take
-        # effect on the next start (not just on first boot). When
-        # `staticNodes` is null, the list `lib.optional` below
-        # evaluates to `[]` and no ExecStartPre fires.
+        # when `staticNodes` is non-null. The file is the legacy
+        # Geth-family mechanism for pinned peers used by this module;
+        # Autonity does not accept a `--staticnodes` CLI flag, while
+        # TOML config (`--config <file>`) is the preferred modern
+        # mechanism upstream and would supersede the file form if
+        # this module ever grows a TOML-config option. `install -m
+        # 0600` overwrites any existing file, ensuring rebuilds with
+        # a changed list always take effect on the next start (not
+        # just on first boot). When `staticNodes` is null, the list
+        # `lib.optional` below evaluates to `[]` and no ExecStartPre
+        # fires.
         ExecStartPre = lib.optional (cfg.staticNodes != null) (
           "${pkgs.coreutils}/bin/install -m 0600 -T "
           + "${pkgs.writeText "static-nodes.json" (builtins.toJSON cfg.staticNodes)} "

--- a/tests/integration.nix
+++ b/tests/integration.nix
@@ -142,8 +142,9 @@ pkgs.testers.nixosTest {
         # below is never dialled); what we want to verify is that
         # the wrapper renders `static-nodes.json` into StateDirectory
         # at unit start with mode 0600 and JSON-serialised content.
-        # The pubkey is 64 zeros — syntactically valid enode URI but
-        # cryptographically meaningless.
+        # The enode node ID / pubkey field below is 128 hex `0`
+        # characters (the full uncompressed secp256k1 pubkey width)
+        # — syntactically valid, but cryptographically meaningless.
         staticNodes = [
           "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000@127.0.0.1:30303"
         ];
@@ -233,6 +234,7 @@ pkgs.testers.nixosTest {
     };
 
   testScript = ''
+    import json
     import re
 
     machine.start()
@@ -252,8 +254,11 @@ pkgs.testers.nixosTest {
     # 1a. `services.autonity.staticNodes` ExecStartPre side-effect.
     #     The fixture above sets a one-element list; this step
     #     asserts the wrapper rendered `static-nodes.json` into
-    #     StateDirectory with mode 0600 and that the JSON content
-    #     round-trips. With DynamicUser the file lives at
+    #     StateDirectory with mode 0600 and that the file parses as
+    #     a single-element JSON array of enode URIs. Parsing rather
+    #     than substring-matching catches malformed JSON, accidental
+    #     wrong list shape (e.g. nested), or a dropped/duplicated
+    #     element. With DynamicUser the file lives at
     #     `/var/lib/private/autonity/static-nodes.json` (root has
     #     full traversal regardless of permission bits), and the
     #     symlink at `/var/lib/autonity` points there.
@@ -263,9 +268,19 @@ pkgs.testers.nixosTest {
         "stat -c %a /var/lib/autonity/static-nodes.json"
     ).strip()
     assert mode == "600", f"static-nodes.json mode is {mode!r}, expected 600"
-    static_nodes = machine.succeed("cat /var/lib/autonity/static-nodes.json")
-    assert "enode://" in static_nodes, (
-        f"static-nodes.json does not contain an enode entry: {static_nodes!r}"
+    static_nodes_raw = machine.succeed("cat /var/lib/autonity/static-nodes.json")
+    static_nodes_json = json.loads(static_nodes_raw)
+    assert isinstance(static_nodes_json, list), (
+        f"static-nodes.json is not a JSON list: {static_nodes_raw!r}"
+    )
+    assert len(static_nodes_json) == 1, (
+        f"static-nodes.json has {len(static_nodes_json)} entries, expected 1: {static_nodes_json!r}"
+    )
+    assert (
+        isinstance(static_nodes_json[0], str)
+        and static_nodes_json[0].startswith("enode://")
+    ), (
+        f"static-nodes.json[0] is not an enode URI: {static_nodes_json!r}"
     )
 
     # ---------------------------------------------------------------

--- a/tests/integration.nix
+++ b/tests/integration.nix
@@ -135,6 +135,18 @@ pkgs.testers.nixosTest {
         p2p.maxPeers = 0;
         p2p.openFirewall = false;
         extraArgs = [ "--nodiscover" ];
+
+        # Exercise the staticNodes ExecStartPre path. The list value
+        # itself is irrelevant for behaviour (the test runs with
+        # `--nodiscover --maxpeers=0`, so even the fake loopback peer
+        # below is never dialled); what we want to verify is that
+        # the wrapper renders `static-nodes.json` into StateDirectory
+        # at unit start with mode 0600 and JSON-serialised content.
+        # The pubkey is 64 zeros — syntactically valid enode URI but
+        # cryptographically meaningless.
+        staticNodes = [
+          "enode://00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000@127.0.0.1:30303"
+        ];
       };
 
       services.blockscout-postgresql = {
@@ -235,6 +247,26 @@ pkgs.testers.nixosTest {
     machine.wait_for_unit("blockscout-backend.service")
     machine.wait_for_unit("blockscout-frontend.service")
     machine.wait_for_unit("nginx.service")
+
+    # ---------------------------------------------------------------
+    # 1a. `services.autonity.staticNodes` ExecStartPre side-effect.
+    #     The fixture above sets a one-element list; this step
+    #     asserts the wrapper rendered `static-nodes.json` into
+    #     StateDirectory with mode 0600 and that the JSON content
+    #     round-trips. With DynamicUser the file lives at
+    #     `/var/lib/private/autonity/static-nodes.json` (root has
+    #     full traversal regardless of permission bits), and the
+    #     symlink at `/var/lib/autonity` points there.
+    # ---------------------------------------------------------------
+    machine.succeed("test -f /var/lib/autonity/static-nodes.json")
+    mode = machine.succeed(
+        "stat -c %a /var/lib/autonity/static-nodes.json"
+    ).strip()
+    assert mode == "600", f"static-nodes.json mode is {mode!r}, expected 600"
+    static_nodes = machine.succeed("cat /var/lib/autonity/static-nodes.json")
+    assert "enode://" in static_nodes, (
+        f"static-nodes.json does not contain an enode entry: {static_nodes!r}"
+    )
 
     # ---------------------------------------------------------------
     # 2. Loopback ports listening.


### PR DESCRIPTION
## Summary

Adds an opt-in `services.autonity.staticNodes` option for pinning peer connections regardless of discovery state. Particularly useful for the deployment this stack targets — a single public-good RPC operator running an Autonity MainNet node — when bootnodes are unavailable or unreliable and the operator needs a way to declare guaranteed peers.

## Mechanism

Autonity inherits Geth's `static-nodes.json` file convention; there is no `--staticnodes` CLI flag. When `staticNodes` is non-null:

- List JSON-serialised at Nix evaluation time and staged via `pkgs.writeText`. Enode URIs are public node-identity hints (not secrets), so store-residency carries no secrecy concern.
- `ExecStartPre=` runs `install -m 0600 -T <staged> $STATE_DIRECTORY/static-nodes.json` at every unit start. `install -T` overwrites any existing file so a rebuilt list takes effect on the next start (not just first boot). Mode 0600, owned by the unit's DynamicUser.
- When `null` (default), `lib.optional` collapses to `[]` and no ExecStartPre fires — clean unit, no on-disk artefacts.

## Verified against the real binary

Integration test fixture sets `staticNodes` to a 128-zero-pubkey enode (cryptographically meaningless but syntactically valid; the test runs `--nodiscover --maxpeers=0` so the fake peer is never dialled). The Autonity binary picks the file up:

```
WARN [04-29|22:42:50.523] Found deprecated node list file
      /var/lib/autonity/static-nodes.json,
      please use the TOML config file instead.
```

Confirms our path + format are accepted. The deprecation warning is inherited verbatim from Geth — the file mechanism still works (warning, not error), just superseded by a TOML config approach upstream. Migrating to `--config <toml>` is broader scope than this option (would require a TOML-config option that supersedes most existing options on this module); will file as a follow-up if real-deployment friction with the deprecated file emerges.

## Hardening matrix

`ExecStartPre` is application/operational config, not a security-relevant `serviceConfig` key per the matrix's documented scope (declared explicitly in `tests/hardening-matrix.nix:28-...` after Copilot round 12 of #19). Hardening drv hash unchanged (`lqhfcckvx8d8`) — no shape drift.

## Test plan

- [x] `nix build .#checks.x86_64-linux.integration` succeeds locally on `x86_64-linux`.
- [x] Step 1a in the testScript asserts `static-nodes.json` exists, mode 0600, and contains an `enode://` entry.
- [x] Autonity binary recognises and reads the file (validated via journalctl WARN line above).
- [x] Existing 9-step integration sequence remains green.

## Out of scope

- TOML-config migration (Geth deprecation message). Broader rewrite; file-based path still works for now and matches what #6's spec asked for.
- `trusted-nodes.json` (separate Geth-family concept; out of scope per #6's "Out of scope" section).
- Dynamic peer updates (would require a sidecar; out of scope per #6).

Refs #6, #3
