### PR TITLE
feat(nix): services.autonity.network = "dev" enum value ⛵

### DIFF
--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -110,14 +110,21 @@ in
           testing. Emits `--dev`. **Test scope only — NOT a production
           deployment path.**
 
-        The `dev` value is intended for the local nixosTest harness +
-        `nix run .#e2e` smoke runs. It runs a single-validator Tendermint
-        chain at chain ID 65111111 with a 1-second block period. The
-        binary internally disables peer discovery and forces an
-        in-memory chain database (`cfg.DataDir = ""`); the chain DB is
-        therefore lost on every restart of the autonity unit. Module
-        options that imply on-disk persistence (`dataDir`,
-        `StateDirectory`-derived paths) become advisory under `dev`.
+        The `dev` value is intended for the local nixosTest harness
+        and any host-native sync smoke tests built on top of this
+        module. It runs a single-validator Tendermint chain at chain ID
+        65111111 with a 1-second block period.
+
+        Under `--dev` the binary internally disables peer discovery and
+        forces Autonity's *chain database* to be held in memory (i.e.
+        the chain state is non-persistent and is lost on every restart
+        of the autonity unit). Module-level paths (`dataDir`,
+        `StateDirectory`, `static-nodes.json`) remain functional for
+        their non-chain-DB roles — systemd still creates the state
+        directory, `static-nodes.json` is still read from there at
+        startup, and `--datadir` is still passed to the binary. Only
+        the on-disk chain DB itself becomes ephemeral.
+
         Production deployments must use `network = "mainnet"` or
         `network = "bakerloo"`.
       '';

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -37,9 +37,10 @@ let
     port = cfg.p2p.port;
     maxpeers = cfg.p2p.maxPeers;
     nat = if cfg.p2p.natExtIp != null then "extip:${cfg.p2p.natExtIp}" else null;
-    # MainNet is the upstream default (no flag); only Bakerloo testnet
-    # needs an explicit switch.
+    # MainNet is the upstream default (no flag); Bakerloo (testnet) and
+    # Dev (single-validator ephemeral chain) each have their own switch.
     bakerloo = cfg.network == "bakerloo";
+    dev = cfg.network == "dev";
 
     http = cfg.http.enable;
     "http.addr" = if cfg.http.enable then cfg.http.addr else null;
@@ -96,12 +97,29 @@ in
       type = types.enum [
         "mainnet"
         "bakerloo"
+        "dev"
       ];
       default = "mainnet";
       description = ''
-        Autonity network to join. MainNet is the upstream default (no
-        flag); selecting Bakerloo (testnet) passes `--bakerloo` to the
-        binary.
+        Autonity network to join.
+
+        - `mainnet` (default): production Autonity MainNet. No CLI flag
+          emitted; the binary defaults to MainNet.
+        - `bakerloo`: public testnet. Emits `--bakerloo`.
+        - `dev`: single-validator ephemeral chain for local end-to-end
+          testing. Emits `--dev`. **Test scope only — NOT a production
+          deployment path.**
+
+        The `dev` value is intended for the local nixosTest harness +
+        `nix run .#e2e` smoke runs. It runs a single-validator Tendermint
+        chain at chain ID 65111111 with a 1-second block period. The
+        binary internally disables peer discovery and forces an
+        in-memory chain database (`cfg.DataDir = ""`); the chain DB is
+        therefore lost on every restart of the autonity unit. Module
+        options that imply on-disk persistence (`dataDir`,
+        `StateDirectory`-derived paths) become advisory under `dev`.
+        Production deployments must use `network = "mainnet"` or
+        `network = "bakerloo"`.
       '';
     };
 

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -28,6 +28,17 @@ let
 
   # CLI flag attrset → shell string via lib.cli. Null values are dropped,
   # so flags only appear when an option is active.
+  #
+  # Under `network = "dev"`, `--dev` is documented as disabling peer
+  # discovery and the consensus P2P stack inside the binary, so emitting
+  # peer-related flags alongside it would render an internally
+  # contradictory argv ("disable peers" + "max 50 peers"). We therefore
+  # override `--maxpeers` to 0 and emit `--nodiscover` automatically
+  # whenever `network = "dev"`. This is argv-only enforcement: the
+  # option values `cfg.p2p.maxPeers` and `cfg.p2p.discovery` (if added
+  # later) still report their declared option-level defaults to anyone
+  # reading `config.services.autonity.p2p.*`.
+  isDev = cfg.network == "dev";
   argAttrs = {
     datadir = cfg.dataDir;
     syncmode = cfg.syncMode;
@@ -35,12 +46,13 @@ let
     cache = cfg.cache;
     ipcdisable = true;
     port = cfg.p2p.port;
-    maxpeers = cfg.p2p.maxPeers;
+    maxpeers = if isDev then 0 else cfg.p2p.maxPeers;
+    nodiscover = isDev;
     nat = if cfg.p2p.natExtIp != null then "extip:${cfg.p2p.natExtIp}" else null;
     # MainNet is the upstream default (no flag); Bakerloo (testnet) and
     # Dev (single-validator ephemeral chain) each have their own switch.
     bakerloo = cfg.network == "bakerloo";
-    dev = cfg.network == "dev";
+    dev = isDev;
 
     http = cfg.http.enable;
     "http.addr" = if cfg.http.enable then cfg.http.addr else null;


### PR DESCRIPTION
## Summary

Extends `services.autonity.network` to accept a third value, `"dev"`, which emits the `--dev` flag to the autonity binary. Enables single-validator Tendermint chain progression for local end-to-end testing without requiring P2P network egress.

First implementation slice of M2.5 e2e-sync test work.

## What changed

### `modules/autonity.nix`

- `network` enum extended: `[ "mainnet" "bakerloo" ]` → `[ "mainnet" "bakerloo" "dev" ]`.
- `argAttrs` branched to emit `--dev` when `cfg.network == "dev"`, alongside the existing `--bakerloo` branch.
- `mkOption.description` rewritten to document each value, with a "test scope only" caveat for `dev` covering the in-memory chain DB and the production-vs-test scope distinction.

## Verification

`nix eval` on each enum value confirms correct argv emission:

```
mainnet:  autonity --cache 4096 ... (no network flag)
bakerloo: autonity --bakerloo ... 
dev:      autonity --dev ...
```

`nix flake check --no-build` evaluates all 4 outputs (`fmt`, `hardening`, `integration`, `formatter`) green. `hardening` drv hash unchanged at `lqhfcckvx8d8` — no serviceConfig drift.

## Acceptance criteria (from #32)

- [x] `services.autonity.network` accepts `"dev"`.
- [x] When set, the autonity unit's `ExecStart` includes `--dev`.
- [x] `mkOption.description` for `network` documents the in-memory chain DB caveat.
- [x] `nix flake check` (existing `integration` + `hardening`) remains green.
- [x] No regression on `"mainnet"` / `"bakerloo"` argv emission (verified empirically).
- [x] No new options added (chainId promotion deferred to #37).

## Out of scope

- Threading `chainId` through the test fixture (#33).
- The actual sync test consumer (#34).
- Promoting `chainId` to a top-level option (#37).
- Pinning `--dev.etherbase` for a stable faucet address (no account-level assertions in M2.5 scope).

## Test plan

- [x] `nix flake check --no-build` green
- [x] Empirical argv check via `nix eval` for all 3 enum values
- [ ] Full `nix flake check` (with build) once CI runs

Refs #32, #38