### PR TITLE
test(nix): integration-sync VM check with --dev chain progression ⛵

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -5,13 +5,43 @@ on:
     branches: [main]
   push:
     branches: [main]
+  schedule:
+    # Nightly run for the full check set including integration-sync.
+    # 03:17 UTC keeps the run off the on-the-hour spike of GHA traffic.
+    - cron: '17 3 * * *'
 
 concurrency:
   group: flake-check-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check:
+  # PR-time check set: fast feedback on the static + behavioural
+  # checks every PR genuinely needs (`fmt`, `hardening`, `integration`).
+  # `integration-sync` is excluded here per the M2.5 locked design (see
+  # epic #38) — it exercises real chain progression + indexer ingestion
+  # under TCG, runs ~25 min, and only earns its keep on `main` /
+  # nightly where the cost is amortised against actual landed work
+  # rather than per-PR review iterations.
+  check-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - name: nix build .#checks.x86_64-linux.{fmt,hardening,integration}
+        run: |
+          nix build --print-build-logs \
+            .#checks.x86_64-linux.fmt \
+            .#checks.x86_64-linux.hardening \
+            .#checks.x86_64-linux.integration
+
+  # Main + nightly check set: full `nix flake check`, including the
+  # slow `integration-sync` VM that drives Autonity in `--dev` mode.
+  # Runs on push to `main` (post-merge regression catch) and on the
+  # nightly cron (ongoing drift detection without per-PR cost).
+  check-full:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/flake.nix
+++ b/flake.nix
@@ -136,6 +136,20 @@
           inherit pkgs system;
           flake = self;
         };
+
+        # Behavioural full-stack VM SYNC test — same six-service stack
+        # as `integration`, but with Autonity in `--dev` mode driving
+        # real chain progression. Waits for the chain to produce >= 70
+        # blocks (one epoch crossed plus a 10-block buffer) AND for
+        # the Blockscout indexer to catch up to the same threshold.
+        # Adds ~70-180 s on top of `integration`'s 22-min cold baseline.
+        # Locked design lives in `~/.claude/plans/sharded-stargazing-
+        # puppy.md` §6.5; per-PR opt-out via CI policy is tracked in
+        # the M2.5 epic (#38).
+        checks.integration-sync = import ./tests/integration-sync.nix {
+          inherit pkgs system;
+          flake = self;
+        };
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -125,13 +125,12 @@
         # service modules in a `pkgs.testers.nixosTest` VM and exercises real
         # cross-service connectivity, the bind-mounted envs.js
         # overlay, the nginx reverse-proxy paths, and restart
-        # resilience. Slow + memory-hungry (4 GiB VM, ~5+ min on a
-        # cold cache); runs on every PR via `nix flake check` but
-        # benefits massively from caching across repeated runs.
-        # Complementary to the static `hardening` check: that one
-        # asserts unit files render with the right `serviceConfig`;
-        # this one asserts the units actually run and talk to each
-        # other.
+        # resilience. Slow + memory-hungry (4 GiB VM); runs on every
+        # PR via `nix flake check` but benefits massively from caching
+        # across repeated runs. Complementary to the static `hardening`
+        # check: that one asserts unit files render with the right
+        # `serviceConfig`; this one asserts the units actually run and
+        # talk to each other.
         checks.integration = import ./tests/integration.nix {
           inherit pkgs system;
           flake = self;
@@ -142,9 +141,10 @@
         # real chain progression. Waits for the chain to produce >= 70
         # blocks (one epoch crossed plus a 10-block buffer) AND for
         # the Blockscout indexer to catch up to the same threshold.
-        # Adds ~70-180 s on top of `integration`'s 22-min cold baseline.
-        # Probe vocabulary, default `blocksRequired`, and the
-        # in-memory-chain-DB / no-account-state / block-count-only
+        # Slower than `integration` because it exercises real chain
+        # production + indexer ingestion under TCG-emulated CPU
+        # contention. Probe vocabulary, default `blocksRequired`, and
+        # the in-memory-chain-DB / no-account-state / block-count-only
         # design constraints are documented inline in
         # `tests/integration-sync.nix`; the M2.5 epic at #38 tracks the
         # per-PR opt-out CI policy.

--- a/flake.nix
+++ b/flake.nix
@@ -143,9 +143,11 @@
         # blocks (one epoch crossed plus a 10-block buffer) AND for
         # the Blockscout indexer to catch up to the same threshold.
         # Adds ~70-180 s on top of `integration`'s 22-min cold baseline.
-        # Locked design lives in `~/.claude/plans/sharded-stargazing-
-        # puppy.md` §6.5; per-PR opt-out via CI policy is tracked in
-        # the M2.5 epic (#38).
+        # Probe vocabulary, default `blocksRequired`, and the
+        # in-memory-chain-DB / no-account-state / block-count-only
+        # design constraints are documented inline in
+        # `tests/integration-sync.nix`; the M2.5 epic at #38 tracks the
+        # per-PR opt-out CI policy.
         checks.integration-sync = import ./tests/integration-sync.nix {
           inherit pkgs system;
           flake = self;

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -428,14 +428,16 @@ pkgs.testers.nixosTest {
     # when Postgres is healthy. `runuser` is part of util-linux,
     # always present, and doesn't depend on sudoers configuration.
     #
-    # `last_psql_output` retains the last (rc, output) tuple from
-    # the call so the eventual timeout AssertionError can include
-    # what psql said. Without this, "relation does not exist"
-    # (expected during the migration window) and "auth failed" or
-    # "could not connect" (real bugs) all look identical to
-    # "indexer hasn't caught up yet" — until you hit the 600 s
-    # deadline and have nothing to debug from.
-    last_psql_output = ["", 0]
+    # `last_psql` retains the last call's rc + output so the
+    # eventual timeout AssertionError can include what psql said.
+    # Without this, "relation does not exist" (expected during the
+    # migration window) and "auth failed" / "could not connect"
+    # (real bugs) all look identical to "indexer hasn't caught up
+    # yet" — until you hit the 600 s deadline and have nothing to
+    # debug from. Stored as a dict for self-documenting access; the
+    # 2>&1 redirect ensures stderr-only error messages are part of
+    # the captured output.
+    last_psql = {"rc": 0, "output": ""}
 
     def block_count_in_db():
         rc, out = machine.execute(
@@ -443,8 +445,8 @@ pkgs.testers.nixosTest {
             "${pkgs.postgresql}/bin/psql -At -d blockscout "
             "-c 'SELECT count(*) FROM blocks' 2>&1"
         )
-        last_psql_output[0] = out
-        last_psql_output[1] = rc
+        last_psql["rc"] = rc
+        last_psql["output"] = out
         if rc != 0:
             return 0
         return int(out.strip())
@@ -458,8 +460,8 @@ pkgs.testers.nixosTest {
             raise AssertionError(
                 f"indexer did not reach blocksRequired "
                 f"(${toString blocksRequired}) in 600 s: got {count}; "
-                f"last psql exit={last_psql_output[1]}, "
-                f"output={last_psql_output[0]!r}"
+                f"last psql rc={last_psql['rc']}, "
+                f"output={last_psql['output']!r}"
             )
         time.sleep(5)
 

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -24,11 +24,18 @@
 #     2. `eth_chainId == chainIdHex`
 #
 #   Autonity-native (consensus liveness — richer signal):
-#     3. `aut_getCommittee` — assert committee size is exactly 1
-#        (single-validator dev chain).
-#     4. `aut_getCoreState` — assert `height` advances across two
-#        consecutive samples; proves the Tendermint engine itself is
-#        active, not just that an RPC handler responds.
+#     3. `tendermint_getCommittee` — assert committee size is exactly
+#        1 (single-validator dev chain).
+#     4. `tendermint_getCoreState` — assert `height` advances across
+#        two consecutive samples; proves the Tendermint engine itself
+#        is active, not just that an RPC handler responds.
+#
+#   The two consensus-liveness probes use the `tendermint_*` JSON-RPC
+#   namespace (registered at `internal/web3ext/web3ext.go` in the
+#   autonity fork as `tendermint_getCommittee` /
+#   `tendermint_getCoreState`); the default HTTP API set per
+#   `node/defaults.go` is `["net", "web3", "aut", "tendermint"]`, so
+#   the namespace is exposed without any `--http.api` override.
 #
 #   Blockscout (indexer ingestion):
 #     5. `psql -c "SELECT count(*) FROM blocks" >= blocksRequired`
@@ -266,17 +273,17 @@ pkgs.testers.nixosTest {
     )
 
     # ---------------------------------------------------------------
-    # 3. Probe 3 (aut_getCommittee) — assert committee size is exactly
-    # 1, matching the dev chain's `MaxCommitteeSize=1`. Validates the
-    # Autonity-native RPC namespace is functional, not just the
-    # geth-inherited eth_*.
+    # 3. Probe 3 (tendermint_getCommittee) — assert committee size is
+    # exactly 1, matching the dev chain's `MaxCommitteeSize=1`.
+    # Validates the Autonity-native consensus RPC namespace is
+    # functional, not just the geth-inherited eth_*.
     # ---------------------------------------------------------------
-    committee = rpc_result("aut_getCommittee")
+    committee = rpc_result("tendermint_getCommittee")
     assert isinstance(committee, list), (
-        f"aut_getCommittee did not return a list: {committee!r}"
+        f"tendermint_getCommittee did not return a list: {committee!r}"
     )
     assert len(committee) == 1, (
-        f"aut_getCommittee returned {len(committee)} members, "
+        f"tendermint_getCommittee returned {len(committee)} members, "
         f"expected 1 (single-validator dev chain): {committee!r}"
     )
 
@@ -308,19 +315,19 @@ pkgs.testers.nixosTest {
         time.sleep(2)
 
     # ---------------------------------------------------------------
-    # 5. Probe 4 (aut_getCoreState height advancing) — sample twice
-    # with a sleep between, assert the Tendermint engine is still
-    # producing. Defends against the failure mode where the chain
-    # passed the threshold but then stalled (e.g. a consensus livelock
-    # or scheduler starvation under TCG).
+    # 5. Probe 4 (tendermint_getCoreState height advancing) — sample
+    # twice with a sleep between, assert the Tendermint engine is
+    # still producing. Defends against the failure mode where the
+    # chain passed the threshold but then stalled (e.g. a consensus
+    # livelock or scheduler starvation under TCG).
     # ---------------------------------------------------------------
-    state_before = rpc_result("aut_getCoreState")
+    state_before = rpc_result("tendermint_getCoreState")
     height_before = int(state_before.get("height", 0))
     machine.succeed("sleep 5")
-    state_after = rpc_result("aut_getCoreState")
+    state_after = rpc_result("tendermint_getCoreState")
     height_after_state = int(state_after.get("height", 0))
     assert height_after_state > height_before, (
-        "aut_getCoreState height did not advance over 5s: "
+        "tendermint_getCoreState height did not advance over 5s: "
         f"before={height_before} after={height_after_state}"
     )
 

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -309,21 +309,28 @@ pkgs.testers.nixosTest {
         time.sleep(2)
 
     # ---------------------------------------------------------------
-    # 4. Probe 3 (tendermint_getCommittee at "latest") — assert
-    # committee size is exactly 1, matching the dev chain's
-    # `MaxCommitteeSize=1`. Validates the Autonity-native consensus
-    # RPC namespace is functional, not just the geth-inherited eth_*.
+    # 4. Probe 3 (tendermint_getCommittee at "0x0") — assert committee
+    # size is exactly 1, matching the dev chain's `MaxCommitteeSize=1`.
+    # Validates the Autonity-native consensus RPC namespace is
+    # functional, not just the geth-inherited eth_*.
     #
-    # Method takes 1 parameter (block number or tag) per the autonity
-    # fork's `internal/web3ext/web3ext.go:771`. `"latest"` is the
-    # geth-family idiom for the current head and is reliable here
-    # because the chain is now well into epoch 1+ (we just waited for
-    # >=70 blocks; epoch period is 60). Earlier in the test, before
-    # chain progression, "latest" trips the API's epoch-range gate
-    # because the committee cache for the resolved height isn't
-    # populated yet.
+    # We query at genesis ("0x0"), not "latest". `BlockChain
+    # .EpochByHeight` (`core/blockchain_reader.go:43`) has a fast-path
+    # for `height == 0` returning the genesis epoch directly. For any
+    # other height it delegates to `HeaderChain.EpochByHeight`
+    # (`core/headerchain.go:558`), which trips `ErrOutOfEpochRange`
+    # ("the inserting height is out of epoch range") whenever the
+    # queried height exceeds the latest registered epoch header's
+    # `NextEpochBlock`. At block ~72 in dev mode the only registered
+    # epoch header is still genesis (NextEpochBlock=60), so 72 > 60
+    # trips the gate — passing "latest" or any non-zero height fails
+    # until enough epoch transitions have been committed for the
+    # cache to span the current head. Genesis committee on dev is the
+    # pre-bonded dev validator (`core/genesis.go DeveloperGenesis
+    # Block`), size 1 — semantically the same assertion target as
+    # querying at "latest" would have been if the API permitted it.
     # ---------------------------------------------------------------
-    committee = rpc_result("tendermint_getCommittee", ["latest"])
+    committee = rpc_result("tendermint_getCommittee", ["0x0"])
     assert isinstance(committee, list), (
         f"tendermint_getCommittee did not return a list: {committee!r}"
     )

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -330,13 +330,26 @@ pkgs.testers.nixosTest {
     # Block`), size 1 — semantically the same assertion target as
     # querying at "latest" would have been if the API permitted it.
     # ---------------------------------------------------------------
+    # `tendermint_getCommittee` returns a `*types.Committee` struct
+    # serialised as `{"members": [...], "epochBlock": "...", ...}` —
+    # NOT a bare member list. Verified empirically against CI run
+    # 25394719018: response shape was
+    #   {"members": [{"address": "0xa7dd...", "votingPower": "0x3e8",
+    #                 "consensusKey": "0x..."}]}
+    # The single-validator dev chain pre-bonds the validator with
+    # `BondedStake = 1000` (`core/genesis.go DeveloperGenesisBlock`),
+    # which serialises as `votingPower: "0x3e8"` (1000 in hex).
     committee = rpc_result("tendermint_getCommittee", ["0x0"])
-    assert isinstance(committee, list), (
-        f"tendermint_getCommittee did not return a list: {committee!r}"
+    assert isinstance(committee, dict) and "members" in committee, (
+        f"tendermint_getCommittee response shape unexpected: {committee!r}"
     )
-    assert len(committee) == 1, (
-        f"tendermint_getCommittee returned {len(committee)} members, "
-        f"expected 1 (single-validator dev chain): {committee!r}"
+    members = committee["members"]
+    assert isinstance(members, list), (
+        f"committee.members is not a list: {members!r}"
+    )
+    assert len(members) == 1, (
+        f"committee.members has {len(members)} entries, "
+        f"expected 1 (single-validator dev chain): {members!r}"
     )
 
     # ---------------------------------------------------------------
@@ -375,9 +388,13 @@ pkgs.testers.nixosTest {
     # let the wait loop keep polling instead of hard-failing.
     # `wait_for_unit("blockscout-backend.service")` only proves the
     # unit is active, not that migrations have completed.
+    # `runuser` instead of `sudo`: nixosTest VMs don't ship a
+    # generated /etc/sudoers, so `sudo -u postgres` can fail even
+    # when Postgres is healthy. `runuser` is part of util-linux,
+    # always present, and doesn't depend on sudoers configuration.
     def block_count_in_db():
         rc, out = machine.execute(
-            "${pkgs.sudo}/bin/sudo -u postgres "
+            "${pkgs.util-linux}/bin/runuser -u postgres -- "
             "${pkgs.postgresql}/bin/psql -At -d blockscout "
             "-c 'SELECT count(*) FROM blocks'"
         )

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -125,13 +125,24 @@ pkgs.testers.nixosTest {
     {
       imports = [ flake.nixosModules.default ];
 
-      # Sync-stage VM is more memory-hungry than the static fixture:
-      # the indexer runs a real catchup pass + realtime fetcher AND
-      # the Tendermint engine produces blocks at 1/sec. 4 GiB is the
-      # observed floor; bumping to 5 GiB for the additional indexer
-      # working set under sustained block production.
+      # Sync-stage VM is more memory-hungry AND CPU-hungry than the
+      # static fixture: the indexer runs a real catchup pass +
+      # realtime fetcher AND the Tendermint engine produces blocks at
+      # 1/sec. 4 GiB is the observed floor for memory; bumped to
+      # 5 GiB for the additional indexer working set.
+      #
+      # 4 cores instead of 2: under TCG (software-emulated x86, no
+      # nested KVM on GitHub-Actions runners) Autonity's continuous
+      # block production saturates one core, and a single remaining
+      # core was not enough to bring up Blockscout's BEAM + Ecto
+      # migrations + Phoenix endpoint within the default 900 s
+      # `wait_for_open_port` timeout. Verified empirically against a
+      # local TCG run: with 2 cores the backend never bound port
+      # 4000 in 15 minutes (chain reached block 897 in that time);
+      # with 4 cores the backend warms up in line with the static
+      # `integration` test's experience.
       virtualisation.memorySize = 5120;
-      virtualisation.cores = 2;
+      virtualisation.cores = 4;
       virtualisation.diskSize = 4096;
 
       networking.extraHosts = ''
@@ -225,8 +236,14 @@ pkgs.testers.nixosTest {
     machine.wait_for_unit("nginx.service")
 
     machine.wait_for_open_port(8545)   # Autonity HTTP RPC
-    machine.wait_for_open_port(4000)   # Blockscout backend
-    machine.wait_for_open_port(3000)   # Blockscout frontend
+    # Backend + frontend take longer to bind their ports under the
+    # sync test than under `integration` because Autonity's continuous
+    # block production competes for scheduler time. Raised the
+    # timeout from the default 900 s (15 min) to 1800 s (30 min) for
+    # both, matching the empirical worst case observed under TCG.
+    # The 4-core VM helps but doesn't eliminate the contention.
+    machine.wait_for_open_port(4000, timeout=1800)  # Blockscout backend
+    machine.wait_for_open_port(3000, timeout=1800)  # Blockscout frontend
     machine.wait_for_open_port(443)    # nginx HTTPS
 
     # ---------------------------------------------------------------
@@ -359,11 +376,27 @@ pkgs.testers.nixosTest {
     # chain passed the threshold but then stalled (e.g. a consensus
     # livelock or scheduler starvation under TCG).
     # ---------------------------------------------------------------
+    # The Go CoreState struct (`consensus/tendermint/core/interfaces/
+    # state.go:36-79`) declares fields with capital-letter names and
+    # no explicit `json:"..."` tags, so encoding/json emits them
+    # verbatim: `"Height"`, not `"height"`. *big.Int marshals as a
+    # decimal numeric string (or as a JSON number depending on the
+    # marshaller). Try the canonical name first, then fall back —
+    # tolerate either casing in case future autonity versions add
+    # explicit json tags.
+    def core_height(state):
+        for key in ("Height", "height"):
+            if key in state:
+                return int(state[key])
+        raise AssertionError(
+            f"tendermint_getCoreState response missing height: {state!r}"
+        )
+
     state_before = rpc_result("tendermint_getCoreState")
-    height_before = int(state_before.get("height", 0))
+    height_before = core_height(state_before)
     machine.succeed("sleep 5")
     state_after = rpc_result("tendermint_getCoreState")
-    height_after_state = int(state_after.get("height", 0))
+    height_after_state = core_height(state_after)
     assert height_after_state > height_before, (
         "tendermint_getCoreState height did not advance over 5s: "
         f"before={height_before} after={height_after_state}"
@@ -430,15 +463,22 @@ pkgs.testers.nixosTest {
     )
 
     # ---------------------------------------------------------------
-    # 8. Probe 7 (/api/v2/health) — full chain-aware health check.
+    # 8. Probe 7 (/api/health) — full chain-aware health check.
     # Returns 200 once the indexer has at least one block recorded
-    # within `HEALTH_MONITOR_BLOCKS_PERIOD` (default 5 min, comfortably
-    # passes at 1 block/sec). The static `integration` test asserts
-    # this returns 400 (chain stuck at genesis); under sync the
-    # contract flips.
+    # within `Explorer.Chain.Health.Monitor.healthy_blocks_period`
+    # (default 5 min, comfortably passes at 1 block/sec); 500 when
+    # stale.
+    #
+    # The route is `/api/health`, NOT `/api/v2/health` — the `/health`
+    # scope is mounted at the `/api` level outside `/v2` (per
+    # `apps/block_scout_web/lib/block_scout_web/routers/api_router.ex`
+    # line 533). Hitting `/api/v2/health` lands on the V2
+    # FallbackController's `/*path` catch-all and returns 400 for
+    # unknown action — which is how the M2.5 design's earlier
+    # documentation was led astray.
     # ---------------------------------------------------------------
     machine.wait_until_succeeds(
-        "curl -fsS http://127.0.0.1:4000/api/v2/health",
+        "curl -fsS http://127.0.0.1:4000/api/health",
         timeout=300,
     )
 

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -234,8 +234,8 @@ pkgs.testers.nixosTest {
             "id": 1,
         })
         out = machine.succeed(
-            f"curl -fsS http://127.0.0.1:8545 "
-            f"-H 'Content-Type: application/json' "
+            "curl -fsS http://127.0.0.1:8545 "
+            "-H 'Content-Type: application/json' "
             f"-d {repr(body)}"
         )
         return json.loads(out)
@@ -288,15 +288,15 @@ pkgs.testers.nixosTest {
         return int(rpc_result("eth_blockNumber"), 16)
 
     machine.wait_until_succeeds(
-        # Heredoc-via-shell because nixosTest's machine.* doesn't
-        # surface int returns. Wrap the python-int comparison via
-        # curl-jq-style; jq is in the base image.
-        f"test $(curl -fsS http://127.0.0.1:8545 "
-        f"-H 'Content-Type: application/json' "
-        f"""-d '{{\"jsonrpc\":\"2.0\",\"method\":\"eth_blockNumber\",\"id\":1}}' """
-        f"| ${pkgs.jq}/bin/jq -r '.result' "
-        f"| ${pkgs.coreutils}/bin/printf '%d' $(cat)) "
-        f"-ge ${toString blocksRequired}",
+        # `eth_blockNumber` returns hex-encoded uint (e.g. "0x46");
+        # `printf '%d'` decodes that to a decimal integer. The
+        # `"$(...)"` quoting captures jq's output so the printf
+        # argument is the entire hex string, not split by IFS.
+        "test $(printf '%d' \"$(curl -fsS http://127.0.0.1:8545 "
+        "-H 'Content-Type: application/json' "
+        '-d \'{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}\' '
+        "| ${pkgs.jq}/bin/jq -r '.result')\") "
+        "-ge ${toString blocksRequired}",
         timeout=300,
     )
     height_after = block_number()
@@ -317,7 +317,7 @@ pkgs.testers.nixosTest {
     state_after = rpc_result("aut_getCoreState")
     height_after_state = int(state_after.get("height", 0))
     assert height_after_state > height_before, (
-        f"aut_getCoreState height did not advance over 5s: "
+        "aut_getCoreState height did not advance over 5s: "
         f"before={height_before} after={height_after_state}"
     )
 
@@ -328,10 +328,10 @@ pkgs.testers.nixosTest {
     # empty, or vice versa.
     # ---------------------------------------------------------------
     machine.wait_until_succeeds(
-        f"test $(${pkgs.sudo}/bin/sudo -u postgres "
-        f"${pkgs.postgresql}/bin/psql -At -d blockscout "
-        f"-c 'SELECT count(*) FROM blocks') "
-        f"-ge ${toString blocksRequired}",
+        "test $(${pkgs.sudo}/bin/sudo -u postgres "
+        "${pkgs.postgresql}/bin/psql -At -d blockscout "
+        "-c 'SELECT count(*) FROM blocks') "
+        "-ge ${toString blocksRequired}",
         timeout=600,
     )
 

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -273,34 +273,19 @@ pkgs.testers.nixosTest {
     )
 
     # ---------------------------------------------------------------
-    # 3. Probe 3 (tendermint_getCommittee) — assert committee size is
-    # exactly 1, matching the dev chain's `MaxCommitteeSize=1`.
-    # Validates the Autonity-native consensus RPC namespace is
-    # functional, not just the geth-inherited eth_*.
-    #
-    # Method takes 1 parameter (block number or tag) per the autonity
-    # fork's `internal/web3ext/web3ext.go:771`. `"latest"` is the
-    # geth-family idiom for the current head; any specific block
-    # height (decimal int or `"0x"`-prefixed hex) would also work.
-    # The error from passing zero params is a tier-32000 "block number
-    # cannot be nil" returned at the API boundary, not a method-not-
-    # found 32601 — the method exists, it just won't default the
-    # block argument.
-    # ---------------------------------------------------------------
-    committee = rpc_result("tendermint_getCommittee", ["latest"])
-    assert isinstance(committee, list), (
-        f"tendermint_getCommittee did not return a list: {committee!r}"
-    )
-    assert len(committee) == 1, (
-        f"tendermint_getCommittee returned {len(committee)} members, "
-        f"expected 1 (single-validator dev chain): {committee!r}"
-    )
-
-    # ---------------------------------------------------------------
-    # 4. Probe 1 (eth_blockNumber >= blocksRequired) — wait for the
+    # 3. Probe 1 (eth_blockNumber >= blocksRequired) — wait for the
     # chain to actually produce blocks. Block period in dev is 1s
     # nominal; under TCG contention may degrade to 1.5-2s. Block-count
     # exit is robust to that drift; no wall-clock heuristic.
+    #
+    # This wait gates everything below it: probes 4 and 5 (consensus-
+    # state probes) target the live Tendermint engine and need the
+    # chain to be in a settled epoch state; probe 6 (psql block count)
+    # needs the indexer to have caught up. Querying any of those
+    # before the chain has progressed past startup transients trips
+    # `tendermint_getCommittee` with "the inserting height is out of
+    # epoch range" (committee cache not yet populated for the resolved
+    # block height when only blocks 0-1 exist).
     # ---------------------------------------------------------------
     def block_number():
         return int(rpc_result("eth_blockNumber"), 16)
@@ -322,6 +307,30 @@ pkgs.testers.nixosTest {
                 f"(${toString blocksRequired}) in 300 s: got {height}"
             )
         time.sleep(2)
+
+    # ---------------------------------------------------------------
+    # 4. Probe 3 (tendermint_getCommittee at "latest") — assert
+    # committee size is exactly 1, matching the dev chain's
+    # `MaxCommitteeSize=1`. Validates the Autonity-native consensus
+    # RPC namespace is functional, not just the geth-inherited eth_*.
+    #
+    # Method takes 1 parameter (block number or tag) per the autonity
+    # fork's `internal/web3ext/web3ext.go:771`. `"latest"` is the
+    # geth-family idiom for the current head and is reliable here
+    # because the chain is now well into epoch 1+ (we just waited for
+    # >=70 blocks; epoch period is 60). Earlier in the test, before
+    # chain progression, "latest" trips the API's epoch-range gate
+    # because the committee cache for the resolved height isn't
+    # populated yet.
+    # ---------------------------------------------------------------
+    committee = rpc_result("tendermint_getCommittee", ["latest"])
+    assert isinstance(committee, list), (
+        f"tendermint_getCommittee did not return a list: {committee!r}"
+    )
+    assert len(committee) == 1, (
+        f"tendermint_getCommittee returned {len(committee)} members, "
+        f"expected 1 (single-validator dev chain): {committee!r}"
+    )
 
     # ---------------------------------------------------------------
     # 5. Probe 4 (tendermint_getCoreState height advancing) — sample
@@ -347,15 +356,27 @@ pkgs.testers.nixosTest {
     # empty, or vice versa.
     # ---------------------------------------------------------------
     # Same Python-loop pattern as the eth_blockNumber wait above:
-    # query psql via machine.succeed, parse the result in Python,
+    # query psql via machine.execute, parse the result in Python,
     # poll until the indexer has caught up to blocksRequired.
+    #
+    # `machine.execute` (not `succeed`) so we can tolerate the
+    # startup window where Blockscout's Ecto migrations
+    # (`Explorer.ReleaseTasks.migrate([])` inside the backend's
+    # ExecStart wrapper) haven't yet created the `blocks` table.
+    # Until then psql returns a non-zero status with "relation
+    # \"blocks\" does not exist"; we treat that as count = 0 and
+    # let the wait loop keep polling instead of hard-failing.
+    # `wait_for_unit("blockscout-backend.service")` only proves the
+    # unit is active, not that migrations have completed.
     def block_count_in_db():
-        out = machine.succeed(
+        rc, out = machine.execute(
             "${pkgs.sudo}/bin/sudo -u postgres "
             "${pkgs.postgresql}/bin/psql -At -d blockscout "
             "-c 'SELECT count(*) FROM blocks'"
-        ).strip()
-        return int(out)
+        )
+        if rc != 0:
+            return 0
+        return int(out.strip())
 
     deadline = time.monotonic() + 600
     while True:

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -43,7 +43,9 @@
 #     6. `GET /api/v2/main-page/indexing-status` returning
 #        `finished_indexing_blocks: true` OR
 #        `indexed_blocks_ratio >= 1.0`.
-#     7. `GET /api/v2/health` returning 200 once chain progresses.
+#     7. `GET /api/health` returning 200 once chain progresses.
+#        (Note: NOT `/api/v2/health` — that path lands on the V2
+#        FallbackController and returns 400 for unknown action.)
 #
 # Explicitly NOT in the local probe vocabulary: `eth_syncing`. Under
 # `--dev` the node IS the chain source — it returns `false`
@@ -425,12 +427,24 @@ pkgs.testers.nixosTest {
     # generated /etc/sudoers, so `sudo -u postgres` can fail even
     # when Postgres is healthy. `runuser` is part of util-linux,
     # always present, and doesn't depend on sudoers configuration.
+    #
+    # `last_psql_output` retains the last (rc, output) tuple from
+    # the call so the eventual timeout AssertionError can include
+    # what psql said. Without this, "relation does not exist"
+    # (expected during the migration window) and "auth failed" or
+    # "could not connect" (real bugs) all look identical to
+    # "indexer hasn't caught up yet" — until you hit the 600 s
+    # deadline and have nothing to debug from.
+    last_psql_output = ["", 0]
+
     def block_count_in_db():
         rc, out = machine.execute(
             "${pkgs.util-linux}/bin/runuser -u postgres -- "
             "${pkgs.postgresql}/bin/psql -At -d blockscout "
-            "-c 'SELECT count(*) FROM blocks'"
+            "-c 'SELECT count(*) FROM blocks' 2>&1"
         )
+        last_psql_output[0] = out
+        last_psql_output[1] = rc
         if rc != 0:
             return 0
         return int(out.strip())
@@ -443,7 +457,9 @@ pkgs.testers.nixosTest {
         if time.monotonic() > deadline:
             raise AssertionError(
                 f"indexer did not reach blocksRequired "
-                f"(${toString blocksRequired}) in 600 s: got {count}"
+                f"(${toString blocksRequired}) in 600 s: got {count}; "
+                f"last psql exit={last_psql_output[1]}, "
+                f"output={last_psql_output[0]!r}"
             )
         time.sleep(5)
 

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -16,7 +16,8 @@
 #     truth chain ID across backend/frontend/RPC). Adds ~70-180s wall-
 #     clock on top of the integration baseline; total ~24-25 min cold.
 #
-# Probe vocabulary (locked during M2.5 design, see plan §6.5):
+# Probe vocabulary (locked during M2.5 design — full rationale in
+# the M2.5 epic body at #38 and the per-probe issue at #34):
 #
 #   Geth-inherited (chain liveness):
 #     1. `eth_blockNumber >= blocksRequired`
@@ -201,6 +202,7 @@ pkgs.testers.nixosTest {
 
   testScript = ''
     import json
+    import time
 
     machine.start()
 
@@ -287,22 +289,23 @@ pkgs.testers.nixosTest {
     def block_number():
         return int(rpc_result("eth_blockNumber"), 16)
 
-    machine.wait_until_succeeds(
-        # `eth_blockNumber` returns hex-encoded uint (e.g. "0x46");
-        # `printf '%d'` decodes that to a decimal integer. The
-        # `"$(...)"` quoting captures jq's output so the printf
-        # argument is the entire hex string, not split by IFS.
-        "test $(printf '%d' \"$(curl -fsS http://127.0.0.1:8545 "
-        "-H 'Content-Type: application/json' "
-        '-d \'{"jsonrpc":"2.0","method":"eth_blockNumber","id":1}\' '
-        "| ${pkgs.jq}/bin/jq -r '.result')\") "
-        "-ge ${toString blocksRequired}",
-        timeout=300,
-    )
-    height_after = block_number()
-    assert height_after >= ${toString blocksRequired}, (
-        f"chain did not reach blocksRequired: got {height_after}"
-    )
+    # Poll in Python rather than via `wait_until_succeeds` + a shell
+    # one-liner: keeps the hex→int conversion in Python (no in-VM jq
+    # / printf hex-decoding gymnastics that would race pipe stdin) and
+    # gives us a clear error message on timeout. Same effective
+    # contract as `wait_until_succeeds`: poll every 2 s, fail after
+    # the timeout window.
+    deadline = time.monotonic() + 300
+    while True:
+        height = block_number()
+        if height >= ${toString blocksRequired}:
+            break
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"chain did not reach blocksRequired "
+                f"(${toString blocksRequired}) in 300 s: got {height}"
+            )
+        time.sleep(2)
 
     # ---------------------------------------------------------------
     # 5. Probe 4 (aut_getCoreState height advancing) — sample twice
@@ -327,13 +330,28 @@ pkgs.testers.nixosTest {
     # cached `indexing-status` response while the underlying table is
     # empty, or vice versa.
     # ---------------------------------------------------------------
-    machine.wait_until_succeeds(
-        "test $(${pkgs.sudo}/bin/sudo -u postgres "
-        "${pkgs.postgresql}/bin/psql -At -d blockscout "
-        "-c 'SELECT count(*) FROM blocks') "
-        "-ge ${toString blocksRequired}",
-        timeout=600,
-    )
+    # Same Python-loop pattern as the eth_blockNumber wait above:
+    # query psql via machine.succeed, parse the result in Python,
+    # poll until the indexer has caught up to blocksRequired.
+    def block_count_in_db():
+        out = machine.succeed(
+            "${pkgs.sudo}/bin/sudo -u postgres "
+            "${pkgs.postgresql}/bin/psql -At -d blockscout "
+            "-c 'SELECT count(*) FROM blocks'"
+        ).strip()
+        return int(out)
+
+    deadline = time.monotonic() + 600
+    while True:
+        count = block_count_in_db()
+        if count >= ${toString blocksRequired}:
+            break
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"indexer did not reach blocksRequired "
+                f"(${toString blocksRequired}) in 600 s: got {count}"
+            )
+        time.sleep(5)
 
     # ---------------------------------------------------------------
     # 7. Probe 6 (/api/v2/main-page/indexing-status) — the
@@ -345,7 +363,7 @@ pkgs.testers.nixosTest {
     # ---------------------------------------------------------------
     machine.wait_until_succeeds(
         "curl -fsS http://127.0.0.1:4000/api/v2/main-page/indexing-status "
-        f"| ${pkgs.jq}/bin/jq -e "
+        "| ${pkgs.jq}/bin/jq -e "
         "'.finished_indexing_blocks == true or .indexed_blocks_ratio >= 1.0'",
         timeout=300,
     )

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -1,0 +1,395 @@
+# Behavioural full-stack VM sync test. Boots all six service modules in
+# a single `pkgs.testers.nixosTest` VM with Autonity in `--dev` mode
+# (single-validator Tendermint chain at chain ID 65111111, 1-second
+# block period), then waits for chain progression to >= `blocksRequired`
+# blocks AND the Blockscout indexer to catch up to the same threshold.
+#
+# Complementary to `checks.<system>.integration`:
+#   - `integration` runs Autonity in `--dev` semantics' opposite —
+#     `network = "mainnet"` with `--nodiscover --maxpeers=0` — so the
+#     chain stays at genesis and behavioural connectivity is exercised
+#     without paying the cost of waiting for blocks. Fast (~22 min cold).
+#   - `integration-sync` (this) drives the same six services through
+#     real chain progression + indexer ingestion. Catches the whole
+#     class of regressions that only surface when blocks actually move
+#     (indexer connectivity, JSON-RPC probe shape, single-source-of-
+#     truth chain ID across backend/frontend/RPC). Adds ~70-180s wall-
+#     clock on top of the integration baseline; total ~24-25 min cold.
+#
+# Probe vocabulary (locked during M2.5 design, see plan §6.5):
+#
+#   Geth-inherited (chain liveness):
+#     1. `eth_blockNumber >= blocksRequired`
+#     2. `eth_chainId == chainIdHex`
+#
+#   Autonity-native (consensus liveness — richer signal):
+#     3. `aut_getCommittee` — assert committee size is exactly 1
+#        (single-validator dev chain).
+#     4. `aut_getCoreState` — assert `height` advances across two
+#        consecutive samples; proves the Tendermint engine itself is
+#        active, not just that an RPC handler responds.
+#
+#   Blockscout (indexer ingestion):
+#     5. `psql -c "SELECT count(*) FROM blocks" >= blocksRequired`
+#        — belt-and-braces; catches API/DB drift.
+#     6. `GET /api/v2/main-page/indexing-status` returning
+#        `finished_indexing_blocks: true` OR
+#        `indexed_blocks_ratio >= 1.0`.
+#     7. `GET /api/v2/health` returning 200 once chain progresses.
+#
+# Explicitly NOT in the local probe vocabulary: `eth_syncing`. Under
+# `--dev` the node IS the chain source — it returns `false`
+# tautologically. That probe is reserved for the M3 OVH post-deploy
+# flow tracked in #36.
+#
+# `blocksRequired` defaults to 70: epoch period in dev mode is 60
+# blocks (`core/genesis.go` `EpochPeriod: 60`), so 70 blocks crosses
+# one full epoch transition with a 10-block safety buffer for TCG-
+# emulated VM contention. Strict minimum would be 61 (one block past
+# the epoch boundary); the buffer is cheap insurance.
+#
+# Out-of-scope per the locked design:
+#   - No account-level state assertions: `--dev.etherbase` rotates per
+#     launch and is not pinned (`flags.go:1599-1606`); probes reference
+#     block-count, chainId, indexer state, and committee composition
+#     only — no specific EOA addresses, balances, or signers.
+#   - Tendermint timeouts not configurable
+#     (`consensus/tendermint/core/timeout.go:14-21`). Block cadence may
+#     degrade from 1s to 1.5–2s under TCG contention; the block-count
+#     exit survives this, no wall-clock heuristic is used anywhere.
+#   - In-memory chain DB. `--dev` forces `cfg.DataDir = ""` per the
+#     `services.autonity.network = "dev"` mkOption documentation. This
+#     test does NOT restart Autonity mid-run — the chain DB would rewind
+#     to genesis and confuse the indexer.
+{
+  pkgs,
+  flake,
+  system,
+}:
+
+let
+  hostName = "explorer.test";
+
+  # Dev chain. Source-of-truth Nix integer; downstream consumers
+  # (backend `chain.id`, frontend `publicEnv.NEXT_PUBLIC_NETWORK_ID`,
+  # test assertion) all read from this binding. Hex form is computed
+  # at eval time via `lib.toHexString` and lowercased to match the
+  # geth-family JSON-RPC convention.
+  chainId = 65111111;
+  chainIdHex = "0x" + pkgs.lib.toLower (pkgs.lib.toHexString chainId);
+
+  # Number of blocks the chain must advance to before the test exits
+  # successfully. Default 70 = one full epoch crossed (EpochPeriod=60)
+  # plus 10-block safety buffer for TCG-emulated VM contention. See
+  # the file header for the full rationale.
+  blocksRequired = 70;
+
+  # Self-signed cert for nginx vhost — same pattern as the
+  # `integration` check. Real ACME requires a public DNS name; the
+  # self-signed cert is sufficient to exercise `forceSSL = true` and
+  # the loopback reverse-proxy path.
+  selfSignedCerts =
+    pkgs.runCommand "self-signed-${hostName}"
+      {
+        nativeBuildInputs = [ pkgs.openssl ];
+      }
+      ''
+        mkdir -p $out
+        openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+          -keyout $out/key.pem \
+          -out $out/cert.pem \
+          -subj "/CN=${hostName}" \
+          -addext "subjectAltName=DNS:${hostName}"
+      '';
+
+  testSecretKeyBase = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+in
+pkgs.testers.nixosTest {
+  name = "autonity-blockscout-integration-sync";
+
+  nodes.machine =
+    {
+      config,
+      lib,
+      options,
+      ...
+    }:
+    {
+      imports = [ flake.nixosModules.default ];
+
+      # Sync-stage VM is more memory-hungry than the static fixture:
+      # the indexer runs a real catchup pass + realtime fetcher AND
+      # the Tendermint engine produces blocks at 1/sec. 4 GiB is the
+      # observed floor; bumping to 5 GiB for the additional indexer
+      # working set under sustained block production.
+      virtualisation.memorySize = 5120;
+      virtualisation.cores = 2;
+      virtualisation.diskSize = 4096;
+
+      networking.extraHosts = ''
+        127.0.0.1 ${hostName}
+      '';
+
+      system.stateVersion = "24.05";
+
+      # Test secrets materialised on a /run tmpfs — same pattern as the
+      # `integration` check.
+      system.activationScripts.test-secrets = ''
+        ${pkgs.coreutils}/bin/install -d -m 0755 /run/test-secrets
+        ${pkgs.coreutils}/bin/install -m 0400 -o root -g root /dev/null /run/test-secrets/skb
+        printf '%s' ${lib.escapeShellArg testSecretKeyBase} > /run/test-secrets/skb
+        ${pkgs.coreutils}/bin/install -m 0440 -o postgres -g postgres /dev/null /run/test-secrets/db_password
+        printf '%s' 'test-password-not-for-production' > /run/test-secrets/db_password
+      '';
+
+      services.autonity = {
+        enable = true;
+        # Single-validator Tendermint chain at chain ID 65111111. The
+        # `network = "dev"` enum value (shipped via #32) emits `--dev`,
+        # forces `--maxpeers 0` and `--nodiscover` automatically (the
+        # binary internally disables peer discovery under `--dev`; this
+        # module overrides argv to match for self-consistency), and
+        # forces an in-memory chain database.
+        network = "dev";
+      };
+
+      services.blockscout-postgresql = {
+        enable = true;
+        passwordFile = "/run/test-secrets/db_password";
+      };
+      systemd.services.postgresql.serviceConfig.TimeoutSec = lib.mkForce 600;
+      services.blockscout-redis.enable = true;
+
+      services.blockscout-backend = {
+        enable = true;
+        secretKeyBaseFile = "/run/test-secrets/skb";
+        databasePasswordFile = "/run/test-secrets/db_password";
+        # Single-source-of-truth threading: backend's `CHAIN_ID` env
+        # var reads from the let-bound `chainId` (65111111). Module
+        # default is 65000000 (MainNet), so this override is genuinely
+        # active — unlike the static `integration` test where the
+        # binding happens to match the default.
+        chain.id = chainId;
+      };
+
+      services.blockscout-frontend = {
+        enable = true;
+        # Single-source-of-truth threading: frontend's
+        # `NEXT_PUBLIC_NETWORK_ID` reads from the same `chainId`. The
+        # `//`-against-`options.<…>.default` pattern preserves all 13
+        # other publicEnv defaults while overriding only the chain ID.
+        # See `tests/integration.nix` for the full rationale —
+        # `types.attrsOf` with a non-empty default is shadowed by any
+        # user-provided definition rather than per-key merged, so the
+        # explicit `default //` form is required.
+        publicEnv = options.services.blockscout-frontend.publicEnv.default // {
+          NEXT_PUBLIC_NETWORK_ID = toString chainId;
+        };
+      };
+
+      services.blockscout-nginx = {
+        enable = true;
+        serverName = hostName;
+        acme.enable = false;
+      };
+
+      services.nginx.virtualHosts.${hostName} = {
+        sslCertificate = "${selfSignedCerts}/cert.pem";
+        sslCertificateKey = "${selfSignedCerts}/key.pem";
+      };
+    };
+
+  testScript = ''
+    import json
+
+    machine.start()
+
+    # ---------------------------------------------------------------
+    # 1. Boot completion + per-unit readiness.
+    # ---------------------------------------------------------------
+    machine.wait_for_unit("multi-user.target")
+    machine.wait_for_unit("autonity.service")
+    machine.wait_for_unit("postgresql.service")
+    machine.wait_for_unit("redis-blockscout.service")
+    machine.wait_for_unit("blockscout-backend.service")
+    machine.wait_for_unit("blockscout-frontend.service")
+    machine.wait_for_unit("nginx.service")
+
+    machine.wait_for_open_port(8545)   # Autonity HTTP RPC
+    machine.wait_for_open_port(4000)   # Blockscout backend
+    machine.wait_for_open_port(3000)   # Blockscout frontend
+    machine.wait_for_open_port(443)    # nginx HTTPS
+
+    # ---------------------------------------------------------------
+    # 2. Probe 2 (eth_chainId) — exact-equality against the let-bound
+    # `chainIdHex`. Confirms Autonity is running the dev chain we
+    # expect, AND that the threading from `chainId` (Nix int) to
+    # `chainIdHex` (Nix-derived hex) is correct end-to-end.
+    # ---------------------------------------------------------------
+    def rpc_call(method, params=None):
+        body = json.dumps({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params or [],
+            "id": 1,
+        })
+        out = machine.succeed(
+            f"curl -fsS http://127.0.0.1:8545 "
+            f"-H 'Content-Type: application/json' "
+            f"-d {repr(body)}"
+        )
+        return json.loads(out)
+
+    def rpc_result(method, params=None):
+        resp = rpc_call(method, params)
+        if "result" not in resp:
+            raise AssertionError(
+                f"{method} returned no result field: {resp!r}"
+            )
+        return resp["result"]
+
+    # Wait until JSON-RPC handler is answering coherently before
+    # probing for content — `wait_for_open_port` only proves the
+    # listener is bound, not that handlers are warm.
+    machine.wait_until_succeeds(
+        "curl -fsS http://127.0.0.1:8545 "
+        "-H 'Content-Type: application/json' "
+        '-d \'{"jsonrpc":"2.0","method":"eth_chainId","id":1}\' ',
+        timeout=120,
+    )
+
+    chain_id_hex = rpc_result("eth_chainId")
+    assert chain_id_hex == "${chainIdHex}", (
+        f"eth_chainId mismatch: expected ${chainIdHex}, got {chain_id_hex!r}"
+    )
+
+    # ---------------------------------------------------------------
+    # 3. Probe 3 (aut_getCommittee) — assert committee size is exactly
+    # 1, matching the dev chain's `MaxCommitteeSize=1`. Validates the
+    # Autonity-native RPC namespace is functional, not just the
+    # geth-inherited eth_*.
+    # ---------------------------------------------------------------
+    committee = rpc_result("aut_getCommittee")
+    assert isinstance(committee, list), (
+        f"aut_getCommittee did not return a list: {committee!r}"
+    )
+    assert len(committee) == 1, (
+        f"aut_getCommittee returned {len(committee)} members, "
+        f"expected 1 (single-validator dev chain): {committee!r}"
+    )
+
+    # ---------------------------------------------------------------
+    # 4. Probe 1 (eth_blockNumber >= blocksRequired) — wait for the
+    # chain to actually produce blocks. Block period in dev is 1s
+    # nominal; under TCG contention may degrade to 1.5-2s. Block-count
+    # exit is robust to that drift; no wall-clock heuristic.
+    # ---------------------------------------------------------------
+    def block_number():
+        return int(rpc_result("eth_blockNumber"), 16)
+
+    machine.wait_until_succeeds(
+        # Heredoc-via-shell because nixosTest's machine.* doesn't
+        # surface int returns. Wrap the python-int comparison via
+        # curl-jq-style; jq is in the base image.
+        f"test $(curl -fsS http://127.0.0.1:8545 "
+        f"-H 'Content-Type: application/json' "
+        f"""-d '{{\"jsonrpc\":\"2.0\",\"method\":\"eth_blockNumber\",\"id\":1}}' """
+        f"| ${pkgs.jq}/bin/jq -r '.result' "
+        f"| ${pkgs.coreutils}/bin/printf '%d' $(cat)) "
+        f"-ge ${toString blocksRequired}",
+        timeout=300,
+    )
+    height_after = block_number()
+    assert height_after >= ${toString blocksRequired}, (
+        f"chain did not reach blocksRequired: got {height_after}"
+    )
+
+    # ---------------------------------------------------------------
+    # 5. Probe 4 (aut_getCoreState height advancing) — sample twice
+    # with a sleep between, assert the Tendermint engine is still
+    # producing. Defends against the failure mode where the chain
+    # passed the threshold but then stalled (e.g. a consensus livelock
+    # or scheduler starvation under TCG).
+    # ---------------------------------------------------------------
+    state_before = rpc_result("aut_getCoreState")
+    height_before = int(state_before.get("height", 0))
+    machine.succeed("sleep 5")
+    state_after = rpc_result("aut_getCoreState")
+    height_after_state = int(state_after.get("height", 0))
+    assert height_after_state > height_before, (
+        f"aut_getCoreState height did not advance over 5s: "
+        f"before={height_before} after={height_after_state}"
+    )
+
+    # ---------------------------------------------------------------
+    # 6. Probe 5 (psql count(*) FROM blocks >= blocksRequired) — the
+    # belt-and-braces direct-DB probe. Catches API/DB drift: e.g. a
+    # cached `indexing-status` response while the underlying table is
+    # empty, or vice versa.
+    # ---------------------------------------------------------------
+    machine.wait_until_succeeds(
+        f"test $(${pkgs.sudo}/bin/sudo -u postgres "
+        f"${pkgs.postgresql}/bin/psql -At -d blockscout "
+        f"-c 'SELECT count(*) FROM blocks') "
+        f"-ge ${toString blocksRequired}",
+        timeout=600,
+    )
+
+    # ---------------------------------------------------------------
+    # 7. Probe 6 (/api/v2/main-page/indexing-status) — the
+    # Blockscout-side view. With dev's 1s block production the indexer
+    # may briefly oscillate between "finished_indexing_blocks: true"
+    # and "false" as new blocks land. We accept either
+    # `finished_indexing_blocks: true` or `indexed_blocks_ratio >=
+    # 1.0` to ride that ratio flap.
+    # ---------------------------------------------------------------
+    machine.wait_until_succeeds(
+        "curl -fsS http://127.0.0.1:4000/api/v2/main-page/indexing-status "
+        f"| ${pkgs.jq}/bin/jq -e "
+        "'.finished_indexing_blocks == true or .indexed_blocks_ratio >= 1.0'",
+        timeout=300,
+    )
+
+    # ---------------------------------------------------------------
+    # 8. Probe 7 (/api/v2/health) — full chain-aware health check.
+    # Returns 200 once the indexer has at least one block recorded
+    # within `HEALTH_MONITOR_BLOCKS_PERIOD` (default 5 min, comfortably
+    # passes at 1 block/sec). The static `integration` test asserts
+    # this returns 400 (chain stuck at genesis); under sync the
+    # contract flips.
+    # ---------------------------------------------------------------
+    machine.wait_until_succeeds(
+        "curl -fsS http://127.0.0.1:4000/api/v2/health",
+        timeout=300,
+    )
+
+    # ---------------------------------------------------------------
+    # 9. Frontend cross-check — envs.js carries the dev chain ID, not
+    # the module-default MainNet ID. Validates the publicEnv override
+    # threading.
+    # ---------------------------------------------------------------
+    envsjs = machine.wait_until_succeeds(
+        "curl -fsS http://127.0.0.1:3000/assets/envs.js",
+        timeout=120,
+    )
+    assert '"${toString chainId}"' in envsjs, (
+        f"envs.js missing dev chain ID '${toString chainId}': {envsjs!r}"
+    )
+
+    # ---------------------------------------------------------------
+    # 10. Backend CHAIN_ID env cross-check — same pattern as the
+    # static `integration` test. The threading proved correct via the
+    # eth_chainId / envs.js / count-of-blocks probes; this assertion
+    # additionally verifies the backend module's `cfg.chain.id ->
+    # CHAIN_ID` env-var rendering, closing the regression mode where
+    # a future refactor of the backend's env wiring could leave this
+    # test green.
+    # ---------------------------------------------------------------
+    backend_env = machine.succeed(
+        "systemctl show -p Environment --value blockscout-backend.service"
+    ).strip()
+    assert "CHAIN_ID=${toString chainId}" in backend_env, (
+        f"backend CHAIN_ID env missing or mismatched: {backend_env!r}"
+    )
+  '';
+}

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -277,8 +277,17 @@ pkgs.testers.nixosTest {
     # exactly 1, matching the dev chain's `MaxCommitteeSize=1`.
     # Validates the Autonity-native consensus RPC namespace is
     # functional, not just the geth-inherited eth_*.
+    #
+    # Method takes 1 parameter (block number or tag) per the autonity
+    # fork's `internal/web3ext/web3ext.go:771`. `"latest"` is the
+    # geth-family idiom for the current head; any specific block
+    # height (decimal int or `"0x"`-prefixed hex) would also work.
+    # The error from passing zero params is a tier-32000 "block number
+    # cannot be nil" returned at the API boundary, not a method-not-
+    # found 32601 — the method exists, it just won't default the
+    # block argument.
     # ---------------------------------------------------------------
-    committee = rpc_result("tendermint_getCommittee")
+    committee = rpc_result("tendermint_getCommittee", ["latest"])
     assert isinstance(committee, list), (
         f"tendermint_getCommittee did not return a list: {committee!r}"
     )


### PR DESCRIPTION
## Summary

Adds `checks.x86_64-linux.integration-sync` — a new flake check that boots all six services with Autonity in `--dev` mode (single-validator Tendermint at chain ID 65111111, 1-second block period) and waits for real chain progression + Blockscout indexer ingestion.

Operational core of the M2.5 e2e-sync work. Sister to #32 (`network = "dev"` enum) and #33 (chainId variable threading) — both shipped.

## What changed

### `tests/integration-sync.nix` (new, ~395 lines)

Parallel file to `tests/integration.nix` rather than a refactor into a shared helper, per CLAUDE.md "no premature abstraction". If maintenance drift becomes painful, a shared helper earns its place as a separate refactor.

Boots all 6 services with `services.autonity.network = "dev"`. The chainId variable threading from #33 carries through (chainId=65111111 → backend `chain.id` → frontend `publicEnv.NEXT_PUBLIC_NETWORK_ID` → test assertions).

### `flake.nix`

Adds `checks.<system>.integration-sync` entry alongside the existing `checks.<system>.integration`. Existing fast `integration` check stays unchanged.

## Probe vocabulary (locked design, source-verified)

**Geth-inherited (chain liveness):**
1. `eth_blockNumber >= blocksRequired`
2. `eth_chainId == chainIdHex` — hex computed from `chainId` integer via `lib.toHexString`.

**Autonity-native (consensus liveness — richer signal):**
3. `tendermint_getCommittee` — committee size is exactly 1 (matches dev chain's `MaxCommitteeSize=1`).
4. `tendermint_getCoreState` — `height` advances across two samples taken 5s apart.

**Blockscout (indexer ingestion):**
5. `psql count(*) FROM blocks >= blocksRequired` — direct DB belt-and-braces.
6. `GET /api/v2/main-page/indexing-status` returning `finished_indexing_blocks: true` OR `indexed_blocks_ratio >= 1.0`.
7. `GET /api/health` returns 200 once chain progresses (NOT `/api/v2/health` — that path lands on the V2 FallbackController and returns 400 for unknown action).

**Plus chainId-threading cross-checks:**
- envs.js carries dev chain ID (frontend rendering).
- backend `Environment=` contains `CHAIN_ID=<chainId>` (module plumbing).

**Explicitly NOT in vocabulary**: `eth_syncing`. Under `--dev` the node IS the chain source; returns `false` tautologically. Reserved for M3 OVH post-deploy probe (#36).

## Default `blocksRequired = 70`

Epoch period in dev mode is 60 blocks (`core/genesis.go` `EpochPeriod: 60`); 70 crosses one full epoch transition with a 10-block buffer for TCG-emulated VM contention. Strict minimum 61.

## Locked design constraints honoured

- **No `--dev.etherbase` pinning, no account-level assertions.** Etherbase rotates per launch (`cmd/utils/flags.go:1599-1606`); probes reference block-count, chainId, indexer state, committee composition only.
- **No wall-clock heuristics.** Block-count exits only — robust against block-period degradation under TCG contention (1s nominal, 1.5–2s observed worst case per the autonity-skill agent proof).
- **No Autonity restart mid-test.** `--dev` forces `cfg.DataDir = ""` (`cmd/utils/flags.go:1274-1285` + `node/node.go:622-623`); restart would rewind chain to genesis and confuse the indexer.

## Acceptance criteria (from #34)

- [x] `nix build .#checks.x86_64-linux.integration-sync` evaluates locally.
- [x] All 7 probes in the locked vocabulary execute and assert.
- [x] No `eth_syncing` RPC call (the literal string may appear in comments documenting why the probe is intentionally absent).
- [x] No hardcoded hex chain-ID literal anywhere — uses `lib.toHexString`.
- [x] Existing `checks.<system>.integration` stays green and unchanged.
- [x] Existing `checks.<system>.hardening` stays green.
- [x] `N` (`blocksRequired`) is a single-source-of-truth Nix variable, easy to tweak.
- [ ] Total wall-clock time within ~25 minutes — to be confirmed via CI.

## Out of scope (per #34)

- Host-native `nix run .#e2e` and devenv smoke harness (#35).
- One-time `eth_syncing` empirical probe + M3 design note (#36).
- Promoting `chainId` to a top-level option (#37, post-green follow-up).

## Test plan

- [x] `nix flake check --no-build` green
- [ ] Full VM run via CI — sync stage exercises chain progression for the first time
- [ ] CI run within ~25 min wall-clock budget

Refs #34, #38