### PR TITLE
feat(nix): one-time eth_syncing empirical probe + M3 design note ⛵

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ The GitHub Actions workflow is the asymmetric one: the PR job runs only the fast
 
 Probe LOGIC is shared via `tests/probes.py`; both the VM testScript and the host-native runner invoke the same Python script with different env-var contracts, so probes don't drift between contexts.
 
+### M3 post-deploy probe (forward reference)
+
+The local sync test asserts boolean chain liveness via `eth_blockNumber` advancement; under `--dev` the node is the chain source so `eth_syncing` returns `false` tautologically and is excluded from the M2.5 vocabulary. M3's MainNet target is the inverse — a freshly-installed node genuinely catches up and `eth_syncing` carries rich object data during the catch-up window. The probe contract for that scenario is locked in [`docs/m3-sync-probe.md`](./docs/m3-sync-probe.md): state-presence check (object → boolean transition) plus minimum block-delta over a configurable probe window. Implementation lands with the M3 host config.
+
 ## License
 
 GPL-3.0-only. See [`LICENSE`](./LICENSE).

--- a/docs/m3-sync-probe.md
+++ b/docs/m3-sync-probe.md
@@ -1,0 +1,152 @@
+# M3 post-deploy sync probe — design lock
+
+This document captures the locked probe contract for verifying that the
+production Autonity node is catching up with MainNet during the M3
+deployment. It is the post-deploy counterpart to the M2.5 local sync
+test (`tests/integration-sync.nix` + `tests/probes.py`) and shares no
+implementation with it — under `--dev` the local test asserts boolean
+chain liveness via `eth_blockNumber` advancement, while M3's MainNet
+target needs the richer `eth_syncing` shape.
+
+## Problem
+
+The M2.5 local sync test exercises Autonity in `--dev` mode (single
+validator, 1 s block period, in-memory chain DB). Under `--dev`, the
+node IS the chain source — there is no notion of "catching up." The
+right liveness probe is `eth_blockNumber` advancing; `eth_syncing`
+returns boolean `false` tautologically because
+`progress.CurrentBlock >= progress.HighestBlock` always holds (see
+`internal/ethapi/api.go:126-132` in the autonity tree).
+
+Production deployment is the inverse: a freshly-installed node
+connects to MainNet peers, downloads headers and state, and
+**genuinely** catches up. `eth_syncing` returns rich object data
+during this window, then transitions to boolean `false` once the head
+matches the network. The M3 probe asserts on both states.
+
+## Empirical verification (2026-05-07)
+
+Before locking the M3 design, the assumption "`eth_syncing` returns
+`false` under `--dev` at all sample points" was empirically verified
+against the `klazomenai/autonity` v1.1.2 build. Boot autonity in
+`--dev` with HTTP RPC bound on `127.0.0.1:8545`, sample at four
+points:
+
+| Sample        | wall-clock | `eth_blockNumber` | `eth_syncing`       |
+|---------------|------------|-------------------|---------------------|
+| RPC ready     | t = 0 s    | `0x0`             | `false`             |
+| after block 1 | t = 1 s    | `0x1`             | `false`             |
+| t = 10 s      | t = 10 s   | `0xa`             | `false`             |
+| t = 60 s      | t = 60 s   | `0x3c`            | `false`             |
+
+Block production is steady at 1 block/s as expected. No transient
+object returns observed at any sample, including across the epoch
+transition at block 60 (`EpochPeriod = 60` per
+`core/genesis.go:944-995`). Result confirms the assumption: under
+`--dev`, `eth_syncing` is uninformative and is correctly excluded
+from the M2.5 probe vocabulary.
+
+## M3 probe contract (locked)
+
+The M3 post-deploy probe asserts the following:
+
+### Probe shape: state-presence, not rate-of-progress
+
+The probe answers one question: "is the node making progress towards
+the network head, or has it reached it?" Rate-of-progress
+(blocks-per-minute, blocks-per-second) is diagnostics-grade and
+belongs in Grafana, not the gating probe.
+
+### Catch-up state
+
+When `progress.CurrentBlock < progress.HighestBlock`, `eth_syncing`
+returns a JSON object with at least `startingBlock`, `currentBlock`,
+`highestBlock`. The probe asserts the response is an **object** (any
+object — schema may vary across Autonity releases), not a boolean.
+
+### Caught-up state
+
+When `progress.CurrentBlock >= progress.HighestBlock`, `eth_syncing`
+returns boolean `false`. The probe asserts boolean equality.
+
+### Progress assertion (during catch-up only)
+
+While in the catch-up state, the probe takes two samples of
+`currentBlock` separated by a probe window (`probeWindowSeconds`,
+default 60), and asserts:
+
+```
+sample2.currentBlock - sample1.currentBlock >= progressBlocks
+```
+
+`progressBlocks` defaults to **10** and is configurable via the M3
+host config (e.g. `services.autonity.m3SyncProbe.progressBlocks`).
+
+The default is conservative: under typical MainNet catch-up rates and
+typical network conditions, ten blocks across a 60-second window
+corresponds to roughly 6 blocks/min — well below the cap a
+non-degraded node sustains and well above zero (a stalled node).
+Operators may tighten under known good conditions.
+
+### Explicit non-goals
+
+- **No wall-clock rate** (blocks-per-minute / blocks-per-second). Just
+  minimum delta over the probe window. Diagnostics-grade rate metrics
+  live in Grafana, not in the gating probe.
+- **No assertion on `startingBlock` / `highestBlock` shape**. Schemas
+  vary across releases; the gate is "object vs boolean," not field
+  membership.
+- **No catch-up timeout**. The probe does not assert "node will be
+  caught up by time T." That's an SLO concern, not a probe concern.
+
+## Configuration surface (sketch — implementation lands with M3 host config)
+
+```nix
+services.autonity.m3SyncProbe = {
+  enable = mkEnableOption "M3 post-deploy sync probe";
+  progressBlocks = mkOption {
+    type = types.ints.positive;
+    default = 10;
+    description = "Minimum currentBlock delta over probeWindowSeconds during catch-up.";
+  };
+  probeWindowSeconds = mkOption {
+    type = types.ints.positive;
+    default = 60;
+    description = "Sample interval for the progress assertion.";
+  };
+};
+```
+
+The probe itself is implemented as a one-shot systemd timer or a
+runbook smoke command — not a long-lived health check. Once `eth_syncing`
+returns `false`, the probe exits 0 and the operator is free to enable
+production traffic.
+
+## Probe vocabulary parity with M2.5
+
+The M2.5 local probe (`tests/probes.py`) and the M3 probe share the
+**vocabulary** but not the **assertions**:
+
+| Probe                       | M2.5 (`--dev`)                     | M3 (MainNet) |
+|-----------------------------|------------------------------------|--------------|
+| `eth_chainId`               | exact equality (`0x3e18447`)       | exact equality (mainnet chainId) |
+| `eth_blockNumber`           | poll until `>= blocksRequired`     | not used (subsumed by `eth_syncing`) |
+| `eth_syncing`               | **excluded** (tautologically false)| object → boolean transition + progress delta |
+| `tendermint_getCommittee`   | size == 1, dev validator           | size == network committee, role-of-this-node check |
+| `tendermint_getCoreState`   | height advances over 5 s           | height advances over probe window |
+| `/api/v2/main-page/indexing-status` | finished or ratio >= 1.0   | same (Blockscout indexer caught up) |
+| `count(*) FROM blocks`      | `>= blocksRequired`                | matches Autonity's `eth_blockNumber` (within tolerance) |
+| `/api/health`               | 200                                | same |
+
+The M2.5 probe's design lock at issue #38 commits to keeping these
+two surfaces in vocabulary lockstep so M3's runbook reuses the
+operator mental model from local development.
+
+## References
+
+- Empirical sample run: 2026-05-07, `klazomenai/autonity` v1.1.2, host kernel 6.17.0
+- Source: `internal/ethapi/api.go:126-132` (`eth_syncing` predicate)
+- Source: `core/genesis.go:944-995` (`DeveloperGenesisBlock`)
+- M2.5 sync test: `tests/integration-sync.nix` + `tests/probes.py`
+- M2.5 design lock: issue #38 (umbrella epic)
+- This document: filed to resolve issue #36

--- a/modules/autonity.nix
+++ b/modules/autonity.nix
@@ -139,6 +139,23 @@ in
 
         Production deployments must use `network = "mainnet"` or
         `network = "bakerloo"`.
+
+        ## `eth_syncing` semantics per network
+
+        - `dev`: returns boolean `false` tautologically — the node IS
+          the chain source, so `progress.CurrentBlock >=
+          progress.HighestBlock` always holds (verified empirically
+          2026-05-07 across four sample points; see
+          `docs/m3-sync-probe.md`). Therefore `eth_syncing` is NOT in
+          the M2.5 local sync probe vocabulary; chain liveness is
+          asserted via `eth_blockNumber` advancing instead.
+        - `mainnet` / `bakerloo`: returns a JSON object with
+          `startingBlock` / `currentBlock` / `highestBlock` during
+          catch-up, then transitions to boolean `false` once the head
+          matches the network. This shape carries the signal needed
+          for the M3 post-deploy probe contract documented at
+          `docs/m3-sync-probe.md` (object vs boolean state-presence
+          check + minimum block-delta over a probe window).
       '';
     };
 


### PR DESCRIPTION
## Summary

- Booted klazomenai/autonity v1.1.2 in `--dev` and empirically sampled `eth_syncing` at four timestamps (t=0, t=1s, t=10s, t=60s including the epoch transition at block 60). All four samples returned boolean `false`. Confirms the assumption locked at #38 — under `--dev` the node IS the chain source so `progress.CurrentBlock >= progress.HighestBlock` holds tautologically (see `internal/ethapi/api.go:126-132`). No transient object returns observed.
- Added `docs/m3-sync-probe.md` capturing the locked M3 post-deploy probe contract: state-presence check (object during catch-up, transitions to boolean `false` once caught up) plus minimum block-delta over a configurable probe window. `progressBlocks` default 10, `probeWindowSeconds` default 60. Includes a vocabulary-parity table documenting which assertions vary across M2.5 (`--dev`) and M3 (MainNet) surfaces.
- Cross-reference comment block added to the `services.autonity.network` enum's option description naming `eth_syncing` semantics per network value (`dev` tautological, `mainnet`/`bakerloo` carrying rich object data during catch-up).
- README forward reference under "Authoritative VM check" so M3 reviewers find the contract before opening host-config PRs.

## Empirical sample data

| Sample        | wall-clock | `eth_blockNumber` | `eth_syncing`       |
|---------------|------------|-------------------|---------------------|
| RPC ready     | t = 0 s    | `0x0`             | `false`             |
| after block 1 | t = 1 s    | `0x1`             | `false`             |
| t = 10 s      | t = 10 s   | `0xa`             | `false`             |
| t = 60 s      | t = 60 s   | `0x3c`            | `false`             |

Block production steady at 1 block/s as expected. Sample at t=60 s deliberately spans the epoch boundary at block 60 (per `core/genesis.go:944-995`'s `EpochPeriod = 60`); no transient object returns observed across the transition.

## Test plan

- [x] `nix flake check --no-build` evaluates green
- [x] `eth_syncing` empirical probe ran end-to-end with all four samples captured
- [x] `docs/m3-sync-probe.md` renders cleanly on GitHub
- [x] `services.autonity.network` option description still renders cleanly in `nix-doc`-style consumers
- [ ] Copilot review cycle (auto on draft PR open)

## Refs

Refs #36 (M2.5 e2e-sync stream, last of six implementation issues). Sister to #32, #33, #34, #35. Followed by #37 follow-up (top-level `services.autonity.chainId` option promotion, optional polish).
