### PR TITLE
chore: gitignore tests/__pycache__ + Release-As override for v0.1.0-alpha.0 ⛵

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ devenv.lock
 # QEMU images (future VM integration tests)
 *.qcow2
 *.img
+
+# Python bytecode cache (tests/probes.py invoked from host-native runs)
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary

- `.gitignore` adds `__pycache__/` and `*.pyc` so `tests/probes.py`'s bytecode cache stops surfacing as untracked on every developer host
- Commit footer carries `Release-As: 0.1.0-alpha.0` to override release-please's default `1.0.0` choice for the first release

## Why

PR #46 (release-please's first release proposal) defaulted to `1.0.0` because manifest `0.0.0` is treated as "no release yet" — the `bump-minor-pre-major` and `prerelease` flags in `.release-please-config.json` only apply *after* a 0.x release exists. They don't influence the first version.

`v0.1.0-alpha.0` matches the rest of the klazomenai fleet's pre-MVP convention (`jwt-auth-service`, `deck-chat`, `KeyRA`, `bridge` all use `vX.Y.Z-alpha.N`) and honestly signals that M3 (Maiden Voyage) hasn't been deployed yet — no production users, no live MainNet RPC.

After this lands, release-please regenerates PR #46 in place to `0.1.0-alpha.0`. Future releases compute normally from that baseline (next `feat:` would become `0.2.0-alpha.0`).

## Test plan

- [ ] CI green (`flake-check` workflow)
- [ ] After merge, release-please workflow runs successfully (was previously failing — fixed by repo Actions permissions toggle, see issue #47)
- [ ] PR #46 regenerates with title `chore(main): release autonity-blockscout-nixos 0.1.0-alpha.0`
- [ ] PR #46 manifest entry reads `"0.1.0-alpha.0"`

Refs #47
