### PR TITLE
test(nix): checks.env-var-contract for PHAROS_* injection contract ⛵

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -49,3 +49,16 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - name: nix flake check
         run: nix flake check --print-build-logs
+
+      # Env-var contract check exercises the PHAROS_* runtimeOverlay
+      # path that `nix flake check` (pure-mode) deliberately skips.
+      # Test values satisfy the option-type regexes for serverName
+      # (RFC 1035 DNS label) and acme.email; they never reach a real
+      # ACME / nginx runtime — the check is eval-time only.
+      - name: nix build .#checks.x86_64-linux.env-var-contract (impure)
+        env:
+          PHAROS_SERVER_NAME: test.example.org
+          PHAROS_ACME_EMAIL: ops@test.example.org
+        run: |
+          nix build --impure --print-build-logs \
+            .#checks.x86_64-linux.env-var-contract

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,26 @@ nix build .#checks.x86_64-linux.deployment-build --print-build-logs
 
 Wall-clock: ~5-15 minutes cold on a fresh checkout, faster on warm cache or Nix-binary-cache hits.
 
+## Env-var contract check
+
+`checks.<system>.env-var-contract` (defined inline in `flake.nix`) verifies that `PHAROS_SERVER_NAME` + `PHAROS_ACME_EMAIL` flow through `--impure` + `builtins.getEnv` to `services.blockscout-nginx.serverName` + `services.blockscout-nginx.acme.email` in `nixosConfigurations.ovh-test`. Catches a class of bug where the env-var name in `flake.nix` drifts from what `deployments/ovh-test/Makefile` exports — silent at eval time, but loud-fail at runtime when ACME tries to issue a cert for `deployment.invalid`.
+
+The check has three eval paths:
+
+- **Pure mode** (default `nix flake check`, no env vars set): emits a `skipped` sentinel explaining how to exercise the verified path. This is the expected outcome under PR-time evaluation.
+- **Impure mode, both PHAROS_* set**: asserts exact-string match. Mismatch throws with a diagnostic naming both expected and actual values.
+- **Impure mode, only one PHAROS_* set**: throws with a pointer to the runtimeOverlay's gate (it requires BOTH set, by design).
+
+**CI invocation**: `check-full` runs a dedicated `--impure` step with test values exported (`test.example.org` / `ops@test.example.org`) exercising the verified path. The test values satisfy the option-type regexes but never reach a real ACME runtime — eval-time only.
+
+Run locally:
+
+```sh
+PHAROS_SERVER_NAME=test.example.org \
+PHAROS_ACME_EMAIL=ops@test.example.org \
+  nix build --impure .#checks.x86_64-linux.env-var-contract --print-build-logs
+```
+
 ## PR workflow
 
 1. Open an issue describing the change.

--- a/flake.nix
+++ b/flake.nix
@@ -349,6 +349,109 @@
           + ")"
         );
 
+        # Env-var contract check for `nixosConfigurations.ovh-test`.
+        # Verifies that PHAROS_SERVER_NAME + PHAROS_ACME_EMAIL flow
+        # through `--impure` + `builtins.getEnv` to the consuming
+        # `services.blockscout-nginx.{serverName,acme.email}` options.
+        #
+        # Failure mode this catches: if a future refactor mistyped
+        # one of the env-var names in `nixosConfigurations.ovh-test`
+        # (e.g. `PHAROS_SERVERNAME` vs `PHAROS_SERVER_NAME`), or if
+        # the runtimeOverlay's gate condition drifted, the placeholders
+        # in `deployments/ovh-test/configuration.nix` would silently
+        # apply and ACME issuance would fail mid-cruise — after the
+        # OVH instance was provisioned and DNS was set up. Asymmetric:
+        # silent-pass at eval time, loud-fail at runtime against paid
+        # hardware. This check converts the silent-pass to a build-
+        # time error.
+        #
+        # Evaluation behaviour:
+        #
+        #   - Pure mode (default `nix flake check`, no env vars set):
+        #     emits a `skipped` sentinel explaining how to exercise
+        #     the check. The skip is intentional — without `--impure`
+        #     and env vars, there's nothing to verify against.
+        #
+        #   - Impure mode, both env vars set: asserts exact-string
+        #     match between PHAROS_* values and the resolved option
+        #     values. Mismatch throws with a diagnostic naming both
+        #     expected and actual (catches placeholder leak-through
+        #     when `--impure` was forgotten on the wrapping invocation).
+        #
+        #   - Impure mode, only one env var set: throws with a
+        #     pointer to the runtimeOverlay's gate (which requires
+        #     BOTH set, by design — half-configured environments
+        #     fall through to placeholders to avoid partial-config
+        #     errors during eval).
+        #
+        # PHAROS_HARDWARE_CONFIG is not asserted here directly: that
+        # value is a path import, not a string comparison, and the
+        # full-closure `deployment-build` check catches its read-
+        # path failures under `--impure` with the env var set.
+        #
+        # CI invocation (in `.github/workflows/flake-check.yml`'s
+        # `check-full` job): a dedicated step exports test values
+        # and runs the check under `--impure`, exercising the
+        # "verified" path. Pure-mode CI in `check-pr` exercises the
+        # "skipped" path (no env vars set, no `--impure`).
+        checks.env-var-contract =
+          let
+            expectedServerName = builtins.getEnv "PHAROS_SERVER_NAME";
+            expectedEmail = builtins.getEnv "PHAROS_ACME_EMAIL";
+            bothSet = expectedServerName != "" && expectedEmail != "";
+            bothUnset = expectedServerName == "" && expectedEmail == "";
+            cfg = self.nixosConfigurations.ovh-test.config.services.blockscout-nginx;
+            actualServerName = cfg.serverName;
+            actualEmail = cfg.acme.email;
+          in
+          if bothUnset then
+            pkgs.writeText "env-var-contract-skipped" ''
+              env-var-contract: skipped (pure-mode evaluation; PHAROS_SERVER_NAME + PHAROS_ACME_EMAIL not set).
+
+              To exercise this check locally:
+                PHAROS_SERVER_NAME=test.example.org \
+                PHAROS_ACME_EMAIL=ops@test.example.org \
+                  nix build --impure .#checks.x86_64-linux.env-var-contract --print-build-logs
+
+              CI exercises the verified path under `check-full`; this skip is the
+              expected outcome under PR-time pure-mode evaluation.
+            ''
+          else if !bothSet then
+            throw ''
+              env-var-contract: only one of PHAROS_SERVER_NAME / PHAROS_ACME_EMAIL is set.
+                PHAROS_SERVER_NAME = ${if expectedServerName == "" then "(unset)" else expectedServerName}
+                PHAROS_ACME_EMAIL  = ${if expectedEmail == "" then "(unset)" else expectedEmail}
+              The flake's runtimeOverlay only applies when BOTH are set; with one
+              set and one unset, the unset half falls back to its placeholder.
+              Set both, or set neither (and let the skipped-sentinel path run).
+            ''
+          else if actualServerName != expectedServerName then
+            throw ''
+              env-var-contract FAILED: serverName mismatch.
+                expected = ${expectedServerName}  (from PHAROS_SERVER_NAME)
+                actual   = ${actualServerName}
+              Placeholder leak-through suggests the runtimeOverlay's getEnv read
+              didn't apply. Confirm `--impure` was passed; if it was, the env-var
+              name in `nixosConfigurations.ovh-test` may have drifted from the
+              PHAROS_SERVER_NAME spelling.
+            ''
+          else if actualEmail != expectedEmail then
+            throw ''
+              env-var-contract FAILED: acme.email mismatch.
+                expected = ${expectedEmail}  (from PHAROS_ACME_EMAIL)
+                actual   = ${actualEmail}
+              Placeholder leak-through suggests the runtimeOverlay's getEnv read
+              didn't apply. Confirm `--impure` was passed; if it was, the env-var
+              name in `nixosConfigurations.ovh-test` may have drifted from the
+              PHAROS_ACME_EMAIL spelling.
+            ''
+          else
+            pkgs.writeText "env-var-contract-verified" ''
+              env-var-contract verified:
+                services.blockscout-nginx.serverName  = ${actualServerName}
+                services.blockscout-nginx.acme.email  = ${actualEmail}
+            '';
+
         # Full-closure build check for `nixosConfigurations.ovh-test`.
         # Where `deployment-eval` (above) catches type errors,
         # assertion failures, and broken imports at evaluation time,


### PR DESCRIPTION
## Summary

Adds `checks.<system>.env-var-contract` — a flake check that verifies the `PHAROS_*` env-var injection contract for `nixosConfigurations.ovh-test`.

Catches a class of bug where the env-var name in `flake.nix` drifts from what `deployments/ovh-test/Makefile` exports (silent at eval time, loud-fail at runtime when ACME tries to issue a cert for `deployment.invalid`). Pre-cruise safety net for `#49`.

## Three eval paths

| Mode | Outcome |
|---|---|
| Pure (default `nix flake check`, no env vars set) | Emits `env-var-contract-skipped` sentinel with instructions for the verified path. **Expected outcome under PR-time evaluation.** |
| Impure, both `PHAROS_SERVER_NAME` + `PHAROS_ACME_EMAIL` set | Asserts exact-string match. Emits `env-var-contract-verified` sentinel on success; throws with diagnostic on mismatch. |
| Impure, only one set | Throws with a pointer to the runtimeOverlay's BOTH-set gate. |

`PHAROS_HARDWARE_CONFIG` is not asserted here directly: that value is a path import, not a string comparison, and the `deployment-build` check (PR #60 / `6c2b611`) catches its read-path failures under `--impure` with the env var set.

## CI integration

`.github/workflows/flake-check.yml`'s `check-full` job gains a dedicated step that exports test values (`test.example.org` / `ops@test.example.org`, both satisfying the option-type regexes but never reaching real ACME / nginx) and runs the check under `--impure`. Pure-mode CI in `check-pr` continues to skip cleanly.

## Local verification

```sh
# Pure-mode path (skipped sentinel):
nix build --no-link --print-out-paths .#checks.x86_64-linux.env-var-contract

# Verified path (sentinel content shows substituted values):
PHAROS_SERVER_NAME=test.example.org \
PHAROS_ACME_EMAIL=ops@test.example.org \
  nix build --impure --no-link .#checks.x86_64-linux.env-var-contract

# Half-set failure path (throws):
PHAROS_SERVER_NAME=test.example.org \
  nix build --impure --no-link .#checks.x86_64-linux.env-var-contract
```

All three exercised locally before push.

## Test plan

- [x] `nix flake check --no-build` — eval green across 8 checks
- [x] Pure-mode build → `env-var-contract-skipped` sentinel
- [x] Impure with both env vars → `env-var-contract-verified` sentinel
- [x] Impure with one env var → throws with half-set diagnostic
- [x] `nix fmt` — formatting clean
- [ ] CI `check-pr` passes (skipped path)
- [ ] CI `check-full` passes (verified path with test values)

Refs #49
Closes #59

