### PR TITLE
test(nix): checks.statix + checks.deadnix flake checks ⛵

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -29,10 +29,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v22
       - uses: DeterminateSystems/magic-nix-cache-action@v13
-      - name: nix build .#checks.x86_64-linux.{fmt,hardening,integration}
+      - name: nix build .#checks.x86_64-linux.{fmt,statix,deadnix,hardening,integration}
         run: |
           nix build --print-build-logs \
             .#checks.x86_64-linux.fmt \
+            .#checks.x86_64-linux.statix \
+            .#checks.x86_64-linux.deadnix \
             .#checks.x86_64-linux.hardening \
             .#checks.x86_64-linux.integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ PHAROS_ACME_EMAIL=ops@test.example.org \
 
 ## Nix lint checks
 
-Every PR runs `checks.<system>.statix` and `checks.<system>.deadnix` as part of `nix flake check`. `statix` catches Nix anti-patterns; `deadnix` catches unused let-bindings, lambda patterns, and function arguments (the `_` prefix marks intentionally-unused lambda patterns and is recognised as such). Repo-level statix config lives at `.statix.toml` with rationale for any globally-disabled rules. Both run in a few seconds.
+Every PR runs `checks.<system>.statix` and `checks.<system>.deadnix` via the `check-pr` job in `.github/workflows/flake-check.yml` (explicit `nix build` of the fast-path check list). `statix` catches Nix anti-patterns; `deadnix` catches unused let-bindings, lambda patterns, and function arguments (the `_` prefix marks intentionally-unused lambda patterns and is recognised as such). Repo-level statix config lives at `statix.toml` (no leading dot — statix searches for the unprefixed name) with rationale for any globally-disabled rules. Both run in a few seconds.
 
 ## PR workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,10 @@ PHAROS_ACME_EMAIL=ops@test.example.org \
   nix build --impure .#checks.x86_64-linux.env-var-contract --print-build-logs
 ```
 
+## Nix lint checks
+
+Every PR runs `checks.<system>.statix` and `checks.<system>.deadnix` as part of `nix flake check`. `statix` catches Nix anti-patterns; `deadnix` catches unused let-bindings, lambda patterns, and function arguments (the `_` prefix marks intentionally-unused lambda patterns and is recognised as such). Repo-level statix config lives at `.statix.toml` with rationale for any globally-disabled rules. Both run in a few seconds.
+
 ## PR workflow
 
 1. Open an issue describing the change.

--- a/deployments/ovh-test/configuration.nix
+++ b/deployments/ovh-test/configuration.nix
@@ -68,7 +68,7 @@
 # `nix flake check` (which runs in pure mode where `getEnv`
 # returns `""`) evaluates cleanly. They are `lib.mkDefault` so the
 # operator overlay overrides them without `mkForce`.
-{ config, lib, ... }:
+{ lib, ... }:
 
 let
   pharosSecretsDir = "/var/lib/pharos-secrets";

--- a/flake.nix
+++ b/flake.nix
@@ -261,9 +261,11 @@
 
         # statix — Nix anti-pattern linter. Walks every tracked `.nix`
         # file from the repo root and exits non-zero on findings.
-        # Repo-level lint config lives at `.statix.toml`; that file
+        # Repo-level lint config lives at `statix.toml` (no leading
+        # dot — statix searches for the unprefixed name); that file
         # documents the rationale for any globally-disabled rules.
-        # Cheap (~few seconds), runs on every PR.
+        # Cheap (~few seconds), runs on every PR via the
+        # `check-pr` job in `.github/workflows/flake-check.yml`.
         checks.statix =
           pkgs.runCommand "check-statix"
             {

--- a/flake.nix
+++ b/flake.nix
@@ -67,14 +67,12 @@
       # used by `apps.<system>.e2e` to construct a host-native runtime
       # PATH that includes the same autonity / blockscout binaries the
       # VM uses.
-      flakeOverlay = (
-        final: _prev: {
-          autonity = autonity.packages.${final.stdenv.hostPlatform.system}.default;
-          autonity-portable = autonity.packages.${final.stdenv.hostPlatform.system}.autonity-portable;
-          blockscout = blockscout.packages.${final.stdenv.hostPlatform.system}.default;
-          blockscout-frontend = blockscout-frontend.packages.${final.stdenv.hostPlatform.system}.default;
-        }
-      );
+      flakeOverlay = final: _prev: {
+        autonity = autonity.packages.${final.stdenv.hostPlatform.system}.default;
+        autonity-portable = autonity.packages.${final.stdenv.hostPlatform.system}.autonity-portable;
+        blockscout = blockscout.packages.${final.stdenv.hostPlatform.system}.default;
+        blockscout-frontend = blockscout-frontend.packages.${final.stdenv.hostPlatform.system}.default;
+      };
     in
     {
       # Top-level aggregate module. Service modules are imported from
@@ -261,6 +259,39 @@
               touch $out
             '';
 
+        # statix — Nix anti-pattern linter. Walks every tracked `.nix`
+        # file from the repo root and exits non-zero on findings.
+        # Repo-level lint config lives at `.statix.toml`; that file
+        # documents the rationale for any globally-disabled rules.
+        # Cheap (~few seconds), runs on every PR.
+        checks.statix =
+          pkgs.runCommand "check-statix"
+            {
+              nativeBuildInputs = [ pkgs.statix ];
+            }
+            ''
+              cd ${self}
+              statix check .
+              touch $out
+            '';
+
+        # deadnix — finds unused symbols (let-bindings, lambda
+        # patterns, function arguments). `--fail` exits non-zero on
+        # findings so CI surfaces them. Convention for keeping
+        # unused-but-intentional lambda patterns is the `_` prefix
+        # (e.g. `_prev` in overlay signatures); deadnix recognises
+        # the prefix and skips those sites.
+        checks.deadnix =
+          pkgs.runCommand "check-deadnix"
+            {
+              nativeBuildInputs = [ pkgs.deadnix ];
+            }
+            ''
+              cd ${self}
+              deadnix --fail .
+              touch $out
+            '';
+
         checks.hardening = import ./tests/hardening-matrix.nix {
           inherit pkgs nixpkgs system;
           flake = self;
@@ -277,7 +308,7 @@
         # `serviceConfig`; this one asserts the units actually run and
         # talk to each other.
         checks.integration = import ./tests/integration.nix {
-          inherit pkgs system;
+          inherit pkgs;
           flake = self;
         };
 
@@ -294,7 +325,7 @@
         # `tests/integration-sync.nix`; the M2.5 epic at #38 tracks the
         # per-PR opt-out CI policy.
         checks.integration-sync = import ./tests/integration-sync.nix {
-          inherit pkgs system;
+          inherit pkgs;
           flake = self;
         };
 

--- a/modules/blockscout-backend.nix
+++ b/modules/blockscout-backend.nix
@@ -72,7 +72,6 @@ let
     mkOption
     mkPackageOption
     mkIf
-    mkBefore
     types
     concatMapStringsSep
     mapAttrsToList

--- a/statix.toml
+++ b/statix.toml
@@ -1,0 +1,31 @@
+# statix lint config — read by `statix check` from the repo root.
+#
+# Disabled rules carry repo-wide rationale below. Rather than ignoring
+# individual sites per rule (which accumulates per-site exemption
+# clutter over time), we make a single global decision so future
+# contributors don't have to relitigate the style call at every
+# offending site.
+disabled = [
+  # manual_inherit_from (W04) — Assignment instead of inherit-from.
+  #
+  # Sites like `cache = cfg.cache;` in option-to-CLI-argv attribute
+  # sets (modules/autonity.nix's argAttrs) sit alongside name-mismatched
+  # assignments (`datadir = cfg.dataDir;`, `syncmode = cfg.syncMode;`).
+  # Rewriting just the name-matched ones to `inherit (cfg) cache;`
+  # would break the visual uniformity of the argv-mapping block.
+  # Conventional Nix accepts both forms; we choose the explicit
+  # assignment form consistently within blocks of this shape.
+  "manual_inherit_from",
+
+  # repeated_keys (W20) — Avoid repeated keys in attribute sets.
+  #
+  # Sites like `services.autonity = {...}; services.blockscout-postgresql
+  # = {...};` use the flat form deliberately to anchor per-service
+  # documentation comments to each top-level stanza. Consolidating
+  # into `services = { autonity = {...}; blockscout-postgresql =
+  # {...}; };` would force all the comments into one nested block
+  # and lose the 1:1 comment-to-stanza relationship that makes
+  # files like deployments/ovh-test/configuration.nix and flake.nix
+  # (per-input `<name>.url = ...; <name>.inputs.* = ...;`) readable.
+  "repeated_keys",
+]

--- a/tests/integration-sync.nix
+++ b/tests/integration-sync.nix
@@ -77,7 +77,6 @@
 {
   pkgs,
   flake,
-  system,
 }:
 
 let
@@ -125,7 +124,6 @@ pkgs.testers.nixosTest {
 
   nodes.machine =
     {
-      config,
       lib,
       ...
     }:

--- a/tests/integration.nix
+++ b/tests/integration.nix
@@ -26,7 +26,6 @@
 {
   pkgs,
   flake,
-  system,
 }:
 
 let
@@ -79,7 +78,6 @@ pkgs.testers.nixosTest {
 
   nodes.machine =
     {
-      config,
       lib,
       ...
     }:


### PR DESCRIPTION
## Summary

Adds two fast Nix static-analysis flake checks plus the inline fixes their first run surfaced.

- `checks.<system>.statix` — `statix check .` from the repo root. Catches Nix anti-patterns. Covered by `check-pr` (seconds).
- `checks.<system>.deadnix` — `deadnix --fail .`. Catches unused let-bindings, lambda patterns, function arguments. Convention for kept-but-unused patterns is the `_` prefix.

Pre-cruise safety net for `#49`. Closes `#53`.

## Pre-existing findings fixed inline

The first run surfaced 7 findings; all fixed cleanly in the same PR (no scope creep per the issue's "fix or follow-up" gate):

| File | Finding | Fix |
|---|---|---|
| `modules/blockscout-backend.nix` | unused `mkBefore` in `inherit (lib)` list | dropped |
| `tests/integration.nix` | unused `system` outer arg | dropped from signature + caller in `flake.nix` |
| `tests/integration.nix` | unused `config` in `nodes.machine` inner signature | dropped (had `...` to absorb) |
| `tests/integration-sync.nix` | unused `system` outer arg | dropped from signature + caller in `flake.nix` |
| `tests/integration-sync.nix` | unused `config` in `nodes.machine` inner signature | dropped |
| `deployments/ovh-test/configuration.nix` | unused `config` lambda arg | dropped |
| `flake.nix` | outer `(...)` around `flakeOverlay = (final: _prev: { ... });` (W08 useless_parens) | dropped |

## statix.toml — globally disabled rules

Repo-level config at `statix.toml` (NOT `.statix.toml` — statix looks for the unprefixed name) disables two style-preference rules with inline rationale documented in the file itself:

- **`manual_inherit_from` (W04)**: name-matched assignments like `cache = cfg.cache;` sit alongside name-mismatched siblings (`datadir = cfg.dataDir;`, `syncmode = cfg.syncMode;`) in `modules/autonity.nix`'s argv-mapping block. Rewriting only the name-matched ones to `inherit (cfg) cache;` would break the visual uniformity of the block.
- **`repeated_keys` (W20)**: the flat `services.autonity = {...}; services.blockscout-postgresql = {...};` form anchors per-stanza documentation comments to each top-level stanza. Consolidating into a single nested `services = { ... };` block forces all the comments into one nested block and loses the 1:1 comment-to-stanza relationship that makes files like `deployments/ovh-test/configuration.nix` and `flake.nix`'s per-input declarations readable.

Global disables in `statix.toml` are preferable to per-site exemption clutter — one decision, one rationale, future contributors don't have to relitigate the style call at every offending site.

## Test plan

- [x] `nix flake check --no-build` — eval green across 10 checks (added `statix` + `deadnix` to the existing eight)
- [x] `nix build --no-link .#checks.x86_64-linux.statix` — exits 0
- [x] `nix build --no-link .#checks.x86_64-linux.deadnix` — exits 0
- [x] `nix run nixpkgs#statix -- check .` — exits 0 with the new config (validates outside the flake-check sandbox)
- [x] `nix fmt` — formatting clean on touched files
- [ ] CI `check-pr` passes (statix + deadnix run in the fast path)
- [ ] CI `check-full` passes (full `nix flake check`)

Refs #49
Closes #53

