### PR TITLE
test(nix): checks.disko-install for deployments/ovh-test disk-config ⛵

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,20 @@ The check runs as part of `nix flake check` alongside `fmt` and `hardening`, but
 - Real ACME / Let's Encrypt — a self-signed cert is wired directly into the nginx vhost; live HTTP-01 validation against a public DNS name is M3.
 - Performance / load testing.
 
+## Disko boot test
+
+`checks.<system>.disko-boot` (defined inline in `flake.nix`) verifies that `deployments/ovh-test/disk-config.nix` produces a valid install by booting a QEMU VM, formatting the virtio disks per the disko spec, and running `nixos-install` (which also installs GRUB). Powered by disko's `makeDiskoTest` framework, which automatically rewrites the spec's `/dev/nvme0n1` to `/dev/vda` for the test VM.
+
+Scope is **disk-config + install phase only** — service modules + the per-instance hardware-config are NOT loaded, and `testBoot = false` skips the post-install boot phase. The check catches GPT layout typos, missing ESP + mountpoint wiring, mkfs / fstab errors, and GRUB install failures (the bootloader install runs as part of `switch-to-configuration boot`, before the boot phase). Boot-time failures (vmlinuz path, initrd, post-boot mount) are covered by `#56`'s full-VM integration test.
+
+The `testBoot = false` choice is empirical: under TCG software emulation (no KVM in the local builder sandbox), the boot phase tests pass quickly but the framework's VM teardown hangs in ACPI poweroff for 15+ minutes before the build artifact materialises. Skipping the boot phase lets the check ship reliably in any environment.
+
+**CI policy**: runs under `check-full` (push to `main` + nightly cron) — not added to `check-pr`'s explicit named-check list because the install phase still takes several minutes under TCG. Run locally before pushing disk-config changes:
+
+```sh
+nix build .#checks.x86_64-linux.disko-boot --print-build-logs
+```
+
 ## Deployment-build check
 
 `checks.<system>.deployment-build` (defined inline in `flake.nix`) forces realisation of the system closure for `nixosConfigurations.ovh-test`. Where the fast `deployment-eval` check above evaluates the option tree (catching type errors, broken imports, and assertion failures), this check actually builds the closure — surfacing derivation build failures, missing dependencies, package compile errors, and overlay conflicts that eval can't see.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,18 +45,18 @@ The check runs as part of `nix flake check` alongside `fmt` and `hardening`, but
 - Real ACME / Let's Encrypt — a self-signed cert is wired directly into the nginx vhost; live HTTP-01 validation against a public DNS name is M3.
 - Performance / load testing.
 
-## Disko boot test
+## Disko install test
 
-`checks.<system>.disko-boot` (defined inline in `flake.nix`) verifies that `deployments/ovh-test/disk-config.nix` produces a valid install by booting a QEMU VM, formatting the virtio disks per the disko spec, and running `nixos-install` (which also installs GRUB). Powered by disko's `makeDiskoTest` framework, which automatically rewrites the spec's `/dev/nvme0n1` to `/dev/vda` for the test VM.
+`checks.<system>.disko-install` (defined inline in `flake.nix`) verifies that `deployments/ovh-test/disk-config.nix` produces a valid install by booting a QEMU VM, formatting the virtio disks per the disko spec, and running `nixos-install` (which also installs GRUB). Powered by disko's `makeDiskoTest` framework, which automatically rewrites the spec's `/dev/nvme0n1` to `/dev/vda` for the test VM.
 
-Scope is **disk-config + install phase only** — service modules + the per-instance hardware-config are NOT loaded, and `testBoot = false` skips the post-install boot phase. The check catches GPT layout typos, missing ESP + mountpoint wiring, mkfs / fstab errors, and GRUB install failures (the bootloader install runs as part of `switch-to-configuration boot`, before the boot phase). Boot-time failures (vmlinuz path, initrd, post-boot mount) are covered by `#56`'s full-VM integration test.
+Scope is **disk-config + install phase only** — service modules + the per-instance hardware-config are NOT loaded, and `testBoot = false` skips the post-install boot phase. The check catches GPT layout typos, missing ESP + mountpoint wiring, mkfs / fstab errors, and GRUB install failures (the bootloader install runs as part of `switch-to-configuration boot`, before the boot phase). Boot-time failures (vmlinuz path drift, initrd composition, post-boot fstab mount, post-boot systemd unit failures) are **not currently covered by any automated check** — `#56` is open to track adding a full-VM integration test of `deployments/ovh-test/configuration.nix` that would supersede this check's boot-time coverage; until that lands, those failure modes surface only on first real-OVH cycle.
 
 The `testBoot = false` choice is empirical: under TCG software emulation (no KVM in the local builder sandbox), the boot phase tests pass quickly but the framework's VM teardown hangs in ACPI poweroff for 15+ minutes before the build artifact materialises. Skipping the boot phase lets the check ship reliably in any environment.
 
-**CI policy**: runs under `check-full` (push to `main` + nightly cron) — not added to `check-pr`'s explicit named-check list because the install phase still takes several minutes under TCG. Run locally before pushing disk-config changes:
+**CI policy**: runs under `check-full` (push to `main` + nightly cron) — not added to `check-pr`'s explicit named-check list because the install phase still takes ~4 min under TCG. Run locally before pushing disk-config changes:
 
 ```sh
-nix build .#checks.x86_64-linux.disko-boot --print-build-logs
+nix build .#checks.x86_64-linux.disko-install --print-build-logs
 ```
 
 ## Deployment-build check

--- a/flake.nix
+++ b/flake.nix
@@ -485,6 +485,58 @@
                 services.blockscout-nginx.acme.email  = ${actualEmail}
             '';
 
+        # Disko boot test for `deployments/ovh-test/disk-config.nix`.
+        # Boots a QEMU VM, formats the virtio disks per the disko
+        # spec, installs a minimal NixOS via `switch-to-configuration
+        # boot` (which also runs the GRUB installer), and verifies
+        # the install phase completes cleanly. Powered by disko's
+        # `makeDiskoTest` framework, which automatically rewrites
+        # the spec's `/dev/nvme0n1` to `/dev/vda` for the test VM.
+        #
+        # Scope: disk-config + install phase only — service modules
+        # + hardware config are NOT loaded. Catches GPT layout
+        # typos, missing ESP + mountpoint wiring, mkfs / fstab
+        # errors, and GRUB install failures (the bootloader install
+        # runs as part of `nixos-enter ... switch-to-configuration
+        # boot`, before the boot phase). Service-composition
+        # validation in a fuller VM is `#56`'s scope.
+        #
+        # `testBoot = false` deliberately skips the post-install
+        # boot phase. Empirical: under TCG software emulation (no
+        # KVM available in the local builder sandbox), the boot
+        # phase tests pass quickly (~7 min) but the framework's VM
+        # teardown hangs in ACPI poweroff for 15+ min before the
+        # build artifact materialises. The install-phase coverage
+        # is the real safety net for first-cruise OVH provisioning
+        # — boot-time failures (vmlinuz path, initrd, post-boot
+        # fstab mount) are caught by `#56`'s full-VM integration
+        # check, which boots the production configuration end-to-
+        # end. Re-enabling `testBoot = true` here can be revisited
+        # if a future CI environment offers reliable nested-virt
+        # KVM acceleration.
+        #
+        # `efi = true` matches `boot.loader.grub.efiSupport = true`
+        # in `deployments/ovh-test/configuration.nix`. The 1 MiB
+        # BIOS-boot partition in the spec elicits a non-fatal
+        # `sgdisk --align-end --new=1:0:+1M` warning during the
+        # install phase (alignment vs minimum-size conflict on the
+        # test VM's disk geometry); disko continues past it and
+        # the partition gets created in the fallback path. Real
+        # OVH B3 instances boot UEFI, so the BIOS-boot partition
+        # is contingency-only and never actually consulted.
+        #
+        # CI policy: lives in the flake checks set so `check-full`
+        # (push to `main` + nightly cron) picks it up automatically.
+        # Not added to `check-pr`'s explicit named-check list — the
+        # install phase still takes several minutes under TCG.
+        checks.disko-boot = disko.lib.testLib.makeDiskoTest {
+          inherit pkgs;
+          name = "ovh-test-disk-boot";
+          disko-config = ./deployments/ovh-test/disk-config.nix;
+          efi = true;
+          testBoot = false;
+        };
+
         # Full-closure build check for `nixosConfigurations.ovh-test`.
         # Where `deployment-eval` (above) catches type errors,
         # assertion failures, and broken imports at evaluation time,

--- a/flake.nix
+++ b/flake.nix
@@ -485,53 +485,65 @@
                 services.blockscout-nginx.acme.email  = ${actualEmail}
             '';
 
-        # Disko boot test for `deployments/ovh-test/disk-config.nix`.
+        # Disko install test for `deployments/ovh-test/disk-config.nix`.
         # Boots a QEMU VM, formats the virtio disks per the disko
-        # spec, installs a minimal NixOS via `switch-to-configuration
-        # boot` (which also runs the GRUB installer), and verifies
-        # the install phase completes cleanly. Powered by disko's
-        # `makeDiskoTest` framework, which automatically rewrites
-        # the spec's `/dev/nvme0n1` to `/dev/vda` for the test VM.
+        # spec, and runs `nixos-install` (which also runs the GRUB
+        # installer via `switch-to-configuration boot`). Powered by
+        # disko's `makeDiskoTest` framework, which automatically
+        # rewrites the spec's `/dev/nvme0n1` to `/dev/vda` for the
+        # test VM.
         #
         # Scope: disk-config + install phase only — service modules
-        # + hardware config are NOT loaded. Catches GPT layout
+        # + hardware config are NOT loaded, and `testBoot = false`
+        # skips the post-install boot phase. Catches GPT layout
         # typos, missing ESP + mountpoint wiring, mkfs / fstab
         # errors, and GRUB install failures (the bootloader install
         # runs as part of `nixos-enter ... switch-to-configuration
-        # boot`, before the boot phase). Service-composition
-        # validation in a fuller VM is `#56`'s scope.
+        # boot`, BEFORE the boot phase). Service-composition
+        # validation in a fuller VM is **planned** under issue #56
+        # (full-VM integration of `deployments/ovh-test/configuration.nix`),
+        # which has not yet shipped — until it does, boot-time
+        # failures (vmlinuz path drift, initrd composition, post-
+        # boot fstab mount, post-boot systemd unit failures) are
+        # NOT covered by any automated check. They surface only on
+        # first real-OVH cycle.
         #
-        # `testBoot = false` deliberately skips the post-install
-        # boot phase. Empirical: under TCG software emulation (no
-        # KVM available in the local builder sandbox), the boot
-        # phase tests pass quickly (~7 min) but the framework's VM
-        # teardown hangs in ACPI poweroff for 15+ min before the
-        # build artifact materialises. The install-phase coverage
-        # is the real safety net for first-cruise OVH provisioning
-        # — boot-time failures (vmlinuz path, initrd, post-boot
-        # fstab mount) are caught by `#56`'s full-VM integration
-        # check, which boots the production configuration end-to-
-        # end. Re-enabling `testBoot = true` here can be revisited
-        # if a future CI environment offers reliable nested-virt
-        # KVM acceleration.
+        # `testBoot = false` decision rationale (empirical): with
+        # `testBoot = true` (the framework default) the boot phase
+        # tests pass quickly under TCG software emulation (no KVM
+        # available in the local builder sandbox) — ~7 min wallclock
+        # for the test script, both `mountpoint /` and `mountpoint
+        # /boot` succeed cleanly. BUT the framework's VM teardown
+        # then hangs in ACPI poweroff for 15+ more minutes before
+        # the build artifact materialises (QEMU CPU drops to ~7%
+        # but the nixos-test-driver keeps waiting on the QMP
+        # shutdown handshake that never completes cleanly). Skipping
+        # the boot phase cuts wallclock from 20+ min (hung in
+        # shutdown) to 4.1 min clean. Re-enabling `testBoot = true`
+        # can be revisited if (a) #56 lands and supersedes this
+        # check's boot-time coverage, or (b) a CI environment
+        # becomes available offering reliable nested-virt KVM
+        # acceleration.
         #
         # `efi = true` matches `boot.loader.grub.efiSupport = true`
         # in `deployments/ovh-test/configuration.nix`. The 1 MiB
         # BIOS-boot partition in the spec elicits a non-fatal
         # `sgdisk --align-end --new=1:0:+1M` warning during the
         # install phase (alignment vs minimum-size conflict on the
-        # test VM's disk geometry); disko continues past it and
-        # the partition gets created in the fallback path. Real
-        # OVH B3 instances boot UEFI, so the BIOS-boot partition
-        # is contingency-only and never actually consulted.
+        # test VM's small disk geometry); disko continues past it
+        # and the partition gets created in the fallback path.
+        # Real OVH B3 instances ship 80+ GiB disks where the
+        # alignment math always succeeds, and they boot UEFI so
+        # the BIOS-boot partition is contingency-only and never
+        # actually consulted.
         #
         # CI policy: lives in the flake checks set so `check-full`
         # (push to `main` + nightly cron) picks it up automatically.
         # Not added to `check-pr`'s explicit named-check list — the
-        # install phase still takes several minutes under TCG.
-        checks.disko-boot = disko.lib.testLib.makeDiskoTest {
+        # install phase still takes ~4 min under TCG.
+        checks.disko-install = disko.lib.testLib.makeDiskoTest {
           inherit pkgs;
-          name = "ovh-test-disk-boot";
+          name = "ovh-test-disk-install";
           disko-config = ./deployments/ovh-test/disk-config.nix;
           efi = true;
           testBoot = false;


### PR DESCRIPTION
## Summary

Adds `checks.<system>.disko-install` — a flake check that boots a QEMU VM, formats the virtio disks per `deployments/ovh-test/disk-config.nix`, and runs `nixos-install` (which includes the GRUB install). Catches GPT layout typos, missing ESP / mountpoint wiring, mkfs / fstab errors, and GRUB install failures — bug classes that would otherwise blow up on first `make install` against paid OVH hardware.

Pre-cruise safety net for `#49`. Closes `#55`.

## testBoot = false — decision and rationale

Initial implementation used `testBoot = true` (the framework default) which also boots the installed system and runs post-boot assertions. **The test script PASSED in 421s** — both `mountpoint /` and `mountpoint /boot` succeeded after the booted_machine reached multi-user.target in 2:46. BUT under TCG software emulation (no KVM in the local builder sandbox), the framework's post-test VM teardown then hung in ACPI poweroff for 15+ more minutes before the build artifact could materialise — QEMU CPU dropped to ~7% but the nixos-test-driver kept waiting on the QMP shutdown handshake that never completed cleanly.

`testBoot = false` skips the post-install boot phase entirely. Cuts wallclock from 20+ min (mostly hung in shutdown) to **4.1 min clean**.

| Trade-off | Coverage at `testBoot = false` |
|---|---|
| ✅ Wrong device path | yes (disko fails) |
| ✅ Bad partition table / GPT layout | yes (sgdisk fails) |
| ✅ Bad filesystem type | yes (mkfs fails) |
| ✅ Mountpoint wiring | yes (mount fails) |
| ✅ GRUB **install** failure | yes (`switch-to-configuration boot` runs as part of install phase, AKA the GRUB installer) |
| ❌ GRUB **boot-time** failure | no — planned under `#56`'s full-VM integration; NOT currently covered |
| ❌ post-boot fstab mount | no — planned under `#56`; NOT currently covered |
| ❌ post-boot systemd unit failures | out of scope (this is `#56`'s territory) |

Future revisit: re-enable `testBoot = true` if a CI environment becomes available that offers reliable KVM acceleration for nested-virt nixos tests.

## sgdisk warnings (non-fatal)

The test surfaces two `Could not create partition N from X to Y` sgdisk warnings during the install phase — one each for partition 1 (1 MiB BIOS-boot, EF02) and partition 3 (root, 100% remainder). These are alignment-vs-minimum-size conflicts on the test VM's small disk geometry (`--align-end` + `+1M` / `+0` boundary cases). Disko's fallback path retries with a metadata-only sgdisk invocation that succeeds; the final partition layout is correct (verified via `disko-format` returning success + subsequent mounts working). Real OVH B3 disks are 80+ GiB so the alignment math always succeeds on actual hardware.

## CI policy

`check-full` (push to `main` + nightly cron) runs this automatically via `nix flake check`. NOT added to `check-pr`'s explicit named-check list — the install phase still takes ~4 min under TCG and would meaningfully add to the PR-time budget.

## Test plan

- [x] `nix flake check --no-build` — eval green across 11 checks
- [x] `nix build --no-link .#checks.x86_64-linux.disko-install --print-build-logs` — completes in 4.1 min wallclock (209s test script + 35s VM setup + cleanup)
- [x] Empirical `testBoot = true` verification — both mountpoint assertions ran successfully on the booted VM (421s test script before the framework-shutdown hang) confirming the disk-config IS bootable; the choice to ship `testBoot = false` is purely about CI reliability, not about the disk-config's correctness
- [x] `nix fmt` — formatting clean
- [ ] CI `check-full` passes (will fire on the next push-to-main or nightly cron)

Refs #49
Closes #55
